### PR TITLE
ci: make container tags consistent

### DIFF
--- a/.github/workflows/container-build-push.yaml
+++ b/.github/workflows/container-build-push.yaml
@@ -131,6 +131,12 @@ jobs:
         uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4.6.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=edge
+            # FIXME: Remove explicit `latest` tag once we start tagging releases
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=tag
+            type=sha,format=long
 
       - name: Create manifest list and push
         working-directory: /tmp/digests


### PR DESCRIPTION
Duplicate the current tag recipe in the merge step.
https://github.com/vipyrsec/dragonfly-client-rs/blob/591356dbb98816e9c18a7a6645eedf2fe0bb4ace/.github/workflows/container-build-push.yaml#L58-L68
https://github.com/vipyrsec/dragonfly-client-rs/blob/591356dbb98816e9c18a7a6645eedf2fe0bb4ace/.github/workflows/container-build-push.yaml#L129-L133