### PR TITLE
ci(container-build-push): disable ARM image build

### DIFF
--- a/.github/workflows/container-build-push.yaml
+++ b/.github/workflows/container-build-push.yaml
@@ -33,7 +33,6 @@ jobs:
       matrix:
         platform:
           - linux/amd64
-          - linux/arm64
 
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
This can be re-enabled, once we have a need for more compute from devices like someone's spare RPi.
