### PR TITLE
ci(rust-ci): publish docs to GitHub Pages

### DIFF
--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -137,6 +137,11 @@ jobs:
       - name: "Checkout repository"
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@dd05243424bd5c0e585e4b55eb2d7615cdd32f1f # v2.5.1
+        with:
+          key: x86_64-unknown-linux-gnu
+
       - name: Download YARA
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
@@ -149,11 +154,6 @@ jobs:
           RUST_BACKTRACE: full
           YARA_INCLUDE_DIR: ${{ github.workspace }}/.yara/${{ needs.yara-test.outputs.include-dir }}
           YARA_LIBRARY_PATH: ${{ github.workspace }}/.yara/${{ needs.yara-test.outputs.library-path }}
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@dd05243424bd5c0e585e4b55eb2d7615cdd32f1f # v2.5.1
-        with:
-          key: x86_64-unknown-linux-gnu
 
       - name: "Upload artifact"
         uses: actions/upload-pages-artifact@a753861a5debcf57bf8b404356158c8e1e33150c # v2.0.0

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -136,4 +136,4 @@ jobs:
       pages: write
       id-token: write
 
-    uses: darbiadev/.github/.github/workflows/github-pages-rust-doc.yaml@f41fb3a79eebcf5a55dd1b85b9c86965d9128db9 # v1.1.0
+    uses: darbiadev/.github/.github/workflows/github-pages-rust-doc.yaml@5f704c2b5aa4a48d52e37e40ba540b15620e45b5 # v1.1.2

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -131,7 +131,7 @@ jobs:
 
   docs-build:
     needs: [yara]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: "Checkout repository"
@@ -175,7 +175,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: "Deploy to GitHub Pages"

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -151,7 +151,6 @@ jobs:
       - name: "Build docs with cargo"
         run: cargo doc --no-deps --document-private-items
         env:
-          RUST_BACKTRACE: full
           YARA_INCLUDE_DIR: ${{ github.workspace }}/.yara/${{ needs.yara.outputs.include-dir }}
           YARA_LIBRARY_PATH: ${{ github.workspace }}/.yara/${{ needs.yara.outputs.library-path }}
 

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -128,3 +128,12 @@ jobs:
           YARA_INCLUDE_DIR: ${{ github.workspace }}/.yara/${{ needs.yara-test.outputs.include-dir }}
           YARA_LIBRARY_PATH: ${{ github.workspace }}/.yara/${{ needs.yara-test.outputs.library-path }}
         run: cargo test --no-fail-fast
+
+  docs:
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    uses: darbiadev/.github/.github/workflows/github-pages-rust-doc.yaml@f41fb3a79eebcf5a55dd1b85b9c86965d9128db9 # v1.1.0

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -129,11 +129,53 @@ jobs:
           YARA_LIBRARY_PATH: ${{ github.workspace }}/.yara/${{ needs.yara-test.outputs.library-path }}
         run: cargo test --no-fail-fast
 
-  docs:
+  docs-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: Download YARA
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: ${{ fromJson(needs.yara-test-output.outputs.result).artifacts[matrix.triple.runs-on] }}
+          path: .yara
+
+      - name: "Build docs with cargo"
+        run: cargo doc --no-deps --document-private-items
+        env:
+          RUST_BACKTRACE: full
+          YARA_INCLUDE_DIR: ${{ github.workspace }}/.yara/${{ needs.yara-test.outputs.include-dir }}
+          YARA_LIBRARY_PATH: ${{ github.workspace }}/.yara/${{ needs.yara-test.outputs.library-path }}
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@dd05243424bd5c0e585e4b55eb2d7615cdd32f1f # v2.5.1
+        with:
+          key: x86_64-unknown-linux-gnu
+
+      - name: "Upload artifact"
+        uses: actions/upload-pages-artifact@a753861a5debcf57bf8b404356158c8e1e33150c # v2.0.0
+        with:
+          path: ./target/doc
+
+  docs-deploy:
+    if: ${{ github.ref == 'refs/heads/main' }}
+
     # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
     permissions:
       contents: read
       pages: write
       id-token: write
 
-    uses: darbiadev/.github/.github/workflows/github-pages-rust-doc.yaml@5f704c2b5aa4a48d52e37e40ba540b15620e45b5 # v1.1.2
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+
+    needs: docs-build
+    steps:
+      - name: "Deploy to GitHub Pages"
+        id: deployment
+        uses: actions/deploy-pages@12ab2b16cf43a7a061fe99da74b6f8f11fb77f5b # v2.0.3

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -130,7 +130,7 @@ jobs:
         run: cargo test --no-fail-fast
 
   docs-build:
-    needs: [yara-test, yara-test-output]
+    needs: [yara]
     runs-on: ubuntu-latest
 
     steps:
@@ -140,7 +140,7 @@ jobs:
       - name: Download YARA
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
-          name: x86_64-unknown-linux-gnu
+          name: ${{ needs.yara.outputs.artifacts }}
           path: .yara
 
       - name: "Build docs with cargo"

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -172,7 +172,7 @@ jobs:
       id-token: write
 
     environment:
-      name: github-pages
+      name: docs
       url: ${{ steps.deployment.outputs.page_url }}
 
     runs-on: ubuntu-22.04

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -152,8 +152,8 @@ jobs:
         run: cargo doc --no-deps --document-private-items
         env:
           RUST_BACKTRACE: full
-          YARA_INCLUDE_DIR: ${{ github.workspace }}/.yara/${{ needs.yara-test.outputs.include-dir }}
-          YARA_LIBRARY_PATH: ${{ github.workspace }}/.yara/${{ needs.yara-test.outputs.library-path }}
+          YARA_INCLUDE_DIR: ${{ github.workspace }}/.yara/${{ needs.yara.outputs.include-dir }}
+          YARA_LIBRARY_PATH: ${{ github.workspace }}/.yara/${{ needs.yara.outputs.library-path }}
 
       - name: "Upload artifact"
         uses: actions/upload-pages-artifact@a753861a5debcf57bf8b404356158c8e1e33150c # v2.0.0

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -130,6 +130,7 @@ jobs:
         run: cargo test --no-fail-fast
 
   docs-build:
+    needs: [yara-test, yara-test-output]
     runs-on: ubuntu-latest
 
     steps:
@@ -139,7 +140,7 @@ jobs:
       - name: Download YARA
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
-          name: ${{ fromJson(needs.yara-test-output.outputs.result).artifacts[matrix.triple.runs-on] }}
+          name: x86_64-unknown-linux-gnu
           path: .yara
 
       - name: "Build docs with cargo"

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -163,7 +163,7 @@ jobs:
   docs-deploy:
     needs: docs-build
 
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: github.ref == 'refs/heads/main'
 
     # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
     permissions:

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -161,6 +161,8 @@ jobs:
           path: ./target/doc
 
   docs-deploy:
+    needs: docs-build
+
     if: ${{ github.ref == 'refs/heads/main' }}
 
     # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -175,7 +177,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    needs: docs-build
     steps:
       - name: "Deploy to GitHub Pages"
         id: deployment


### PR DESCRIPTION
Part of the efforts to get documentation going. It's just generated docs of the internal API, but it gets us an already automated jumping off point.