### PR TITLE
Ignore everything that requires the container to be actually published on PR builds

### DIFF
--- a/.github/workflows/container-build-push.yaml
+++ b/.github/workflows/container-build-push.yaml
@@ -116,6 +116,7 @@ jobs:
       # data. If you would like to publish transparency data even for private images, pass --force to cosign below.
       # https://github.com/sigstore/cosign
       - name: Sign the published Docker image
+        if: ${{ github.ref == 'refs/heads/main' || startswith(github.event.ref, 'refs/tags/v') }}
         env:
           COSIGN_EXPERIMENTAL: 'true'
         shell: bash

--- a/.github/workflows/container-build-push.yaml
+++ b/.github/workflows/container-build-push.yaml
@@ -125,12 +125,14 @@ jobs:
         run: cosign sign ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.docker_build_push.outputs.digest }}
 
       - name: Export digest
+        if: ${{ github.ref == 'refs/heads/main' || startswith(github.event.ref, 'refs/tags/v') }}
         run: |
           mkdir -p /tmp/digests
           digest='${{ steps.docker_build_push.outputs.digest }}'
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
+        if: ${{ github.ref == 'refs/heads/main' || startswith(github.event.ref, 'refs/tags/v') }}
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32  # v3.1.3
         with:
           if-no-files-found: error
@@ -139,6 +141,7 @@ jobs:
           retention-days: 1
 
   merge:
+    if: ${{ github.ref == 'refs/heads/main' || startswith(github.event.ref, 'refs/tags/v') }}
     needs: [build-push]
 
     runs-on: ubuntu-22.04


### PR DESCRIPTION
It's not published, so they won't be there.