### PR TITLE
ci(yara): overwrite the artifact when uploading

### DIFF
--- a/.github/workflows/yara.yaml
+++ b/.github/workflows/yara.yaml
@@ -1,3 +1,4 @@
+---
 name: YARA
 
 on:
@@ -9,7 +10,7 @@ on:
         type: string
       version:
         description: YARA version
-        default: "4.3.1"
+        default: 4.3.1
         required: false
         type: string
     outputs:
@@ -23,26 +24,38 @@ on:
         description: YARA Library Path
         value: .libs
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   yara:
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Cache YARA
         id: cache-yara
-        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2  # v4.0.0
         with:
           key: yara-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}
           path: yara-${{ inputs.version }}
 
       - name: Compile YARA
-        if: steps.cache-yara.outputs.cache-hit != 'true' && runner.os == 'Linux'
         run: |
+          #/usr/bin/env bash
           set -e
-          curl -sL https://github.com/VirusTotal/yara/archive/refs/tags/v${{ inputs.version }}.tar.gz -o yara-${{ inputs.version }}.tar.gz
-          tar -xzf yara-${{ inputs.version }}.tar.gz && cd yara-${{ inputs.version }} && ./bootstrap.sh && ./configure && make
+
+          curl -sL \
+              https://github.com/VirusTotal/yara/archive/refs/tags/v${{ inputs.version }}.tar.gz \
+              -o yara-${{ inputs.version }}.tar.gz
+          tar -xzf yara-${{ inputs.version }}.tar.gz
+          cd yara-${{ inputs.version }}
+          ./bootstrap.sh
+          ./configure
+          make
+        if: steps.cache-yara.outputs.cache-hit != 'true' && runner.os == 'Linux'
 
       - name: Upload YARA
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8  # v4.3.0
         with:
           if-no-files-found: error
           name: yara-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}
@@ -51,6 +64,7 @@ jobs:
             yara-${{ inputs.version }}/libyara/include/yara.h
             yara-${{ inputs.version }}/.libs/libyara*
           retention-days: 1
+          overwrite: true
 
     outputs:
       artifacts: yara-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}


### PR DESCRIPTION
This avoids a conflict when this workflow is called multiple times from a job.
