### PR TITLE
build: remove installation of the YARA C library from the container image build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,35 +4,11 @@ ARG DEBIAN_VERSION=bookworm
 ARG DEBIAN_VERSION_NUMBER=12
 ARG PROJECT=dragonfly-client-rs
 ARG RUST_VERSION=1.78
-ARG RUSTFLAGS="-L/usr/local/lib"
-
-ARG YARA_VERSION=4.5.1
 
 # ====================================================================================================
 # Base
 FROM rust:${RUST_VERSION}-${DEBIAN_VERSION} AS build-base
 ARG PROJECT
-
-ARG RUSTFLAGS
-ARG YARA_VERSION
-
-RUN <<EOT
-#!/usr/bin/env bash
-set -e
-
-apt-get -q update
-apt-get -qy --no-install-recommends install curl libclang-dev
-rm -rf /var/lib/apt/lists/*
-EOT
-
-RUN <<EOT
-#!/usr/bin/env bash
-set -euo pipefail
-
-archive_filename="yara-${YARA_VERSION}.tar.gz"
-curl -sL "https://github.com/VirusTotal/yara/archive/refs/tags/v${YARA_VERSION}.tar.gz" -o "${archive_filename}"
-tar -xzf "${archive_filename}" && cd "yara-${YARA_VERSION}" && ./bootstrap.sh && ./configure && make && make install
-EOT
 
 WORKDIR /app
 COPY .cargo Cargo.toml ./
@@ -44,8 +20,8 @@ FROM build-base AS build-debug
 ARG PROJECT
 
 RUN --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
-    --mount=type=cache,id=rust-target-debug,target=/app/target \
-    <<EOT
+  --mount=type=cache,id=rust-target-debug,target=/app/target \
+  <<EOT
 #!/usr/bin/env bash
 set -eu
 
@@ -57,8 +33,8 @@ EOT
 
 COPY src src
 RUN --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
-    --mount=type=cache,id=rust-target-debug,target=/app/target \
-    cargo build --locked && cp /app/target/debug/${PROJECT} /app/${PROJECT}
+  --mount=type=cache,id=rust-target-debug,target=/app/target \
+  cargo build --locked && cp /app/target/debug/${PROJECT} /app/${PROJECT}
 
 # ==================================================
 FROM gcr.io/distroless/cc-debian${DEBIAN_VERSION_NUMBER}:debug-nonroot AS debug
@@ -76,8 +52,8 @@ FROM build-base AS build-release
 ARG PROJECT
 
 RUN --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
-    --mount=type=cache,id=rust-target-release,target=/app/target \
-    <<EOT
+  --mount=type=cache,id=rust-target-release,target=/app/target \
+  <<EOT
 #!/usr/bin/env bash
 set -eu
 
@@ -89,8 +65,8 @@ EOT
 
 COPY src src
 RUN --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
-    --mount=type=cache,id=rust-target-release,target=/app/target \
-    cargo build --locked --release && cp /app/target/release/${PROJECT} /app/${PROJECT}
+  --mount=type=cache,id=rust-target-release,target=/app/target \
+  cargo build --locked --release && cp /app/target/release/${PROJECT} /app/${PROJECT}
 
 # ==================================================
 FROM gcr.io/distroless/cc-debian${DEBIAN_VERSION_NUMBER}:nonroot AS release


### PR DESCRIPTION
Since the dependency on the YARA C library is remove with YARA-X, this
is no longer necessary.
