### PR TITLE
ci(container-build-push): unpin Cosign

### DIFF
--- a/.github/workflows/container-build-push.yaml
+++ b/.github/workflows/container-build-push.yaml
@@ -39,8 +39,6 @@ jobs:
 
       - name: Install cosign
         uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20  # v3.5.0
-        with:
-          cosign-release: v1.13.1
 
       - name: Setup Docker Buildx
         id: buildx


### PR DESCRIPTION
`cosign-installer` installs `v2.2.4` by default, but we were pinned to `v1.13.1`.
This should resolve the issue with signing the container image.
