### PR TITLE
Bound scanner memory usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,17 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures 0.2.17",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,15 +124,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,15 +140,6 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
-
-[[package]]
-name = "bzip2"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
-dependencies = [
- "libbz2-rs-sys",
-]
 
 [[package]]
 name = "cc"
@@ -210,18 +181,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "rand_core",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
 ]
 
 [[package]]
@@ -299,12 +260,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
-name = "constant_time_eq"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,15 +287,6 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -355,39 +301,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "deflate64"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
-
-[[package]]
-name = "deranged"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -583,16 +496,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,20 +510,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -628,7 +517,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
  "rand_core",
  "wasm-bindgen",
 ]
@@ -669,15 +558,6 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
 
 [[package]]
 name = "http"
@@ -905,15 +785,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,12 +879,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
-name = "libbz2-rs-sys"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
-
-[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1061,15 +926,6 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
-name = "lzma-rust2"
-version = "0.15.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e20f57f9918e5bd7bc58c22cdd70a6afc7375d4dd9683af5f2b34bd3d2bba619"
-dependencies = [
- "sha2",
-]
 
 [[package]]
 name = "matchers"
@@ -1139,12 +995,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
-
-[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,16 +1042,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest",
- "hmac",
 ]
 
 [[package]]
@@ -1259,18 +1099,6 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
-name = "ppmd-rust"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
 
 [[package]]
 name = "proc-macro2"
@@ -1359,12 +1187,6 @@ checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -1738,28 +1560,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1971,26 +1771,6 @@ checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "time"
-version = "0.3.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
-dependencies = [
- "deranged",
- "js-sys",
- "num-conv",
- "powerfmt",
- "serde_core",
- "time-core",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tinystr"
@@ -2230,12 +2010,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
-name = "typenum"
-version = "1.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
 name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2310,15 +2084,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2540,12 +2305,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2639,20 +2398,6 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
 
 [[package]]
 name = "zerotrie"
@@ -2693,26 +2438,11 @@ version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
 dependencies = [
- "aes",
- "bzip2",
- "constant_time_eq",
  "crc32fast",
- "deflate64",
  "flate2",
- "generic-array",
- "getrandom 0.3.4",
- "hmac",
  "indexmap",
- "lzma-rust2",
  "memchr",
- "pbkdf2",
- "ppmd-rust",
- "sha1",
- "time",
  "typed-path",
- "zeroize",
- "zopfli",
- "zstd",
 ]
 
 [[package]]
@@ -2726,43 +2456,3 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
-
-[[package]]
-name = "zopfli"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
-dependencies = [
- "bumpalo",
- "crc32fast",
- "log",
- "simd-adler32",
-]
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ tracing-subscriber = {version = "0.3.22", features = ["env-filter"]}
 walkdir = "2.5.0"
 yara = "0.31.0"
 yara-sys = {version = "0.31.0", features = ["vendored"]}
-zip = "7.0.0"
+zip = {version = "7.0.0", default-features = false, features = ["deflate-flate2-zlib-rs"]}
 
 [profile.release]
 strip = true

--- a/README.md
+++ b/README.md
@@ -112,9 +112,10 @@ stages each compressed distribution on temporary disk, validates its resource
 limits, and extracts it. Files are scanned individually from disk by YARA.
 Only the highest-scoring file and unique matched rules are retained for each
 distribution. After every distribution finishes, the client unions matched
-rules across the complete package, sums each unique rule's score once, and
-submits one package verdict to the API. The inspector URL identifies the
-highest-scoring file anywhere in the package.
+rule identifiers across the complete package and submits one package verdict
+to the API. Its score is the maximum independently calculated distribution
+score; evidence from mutually exclusive distributions is not added together.
+The inspector URL identifies the highest-scoring file in that distribution.
 
 The client requests at most one job per configured worker, up to
 `DRAGONFLY_BULK_SIZE`, and scans those packages concurrently. Each package's

--- a/README.md
+++ b/README.md
@@ -81,31 +81,12 @@ sender thread.
 ### Performance, efficiency, and optimization
 
 The client aims to be highly configurable to suit a variety of host machines.
-The environment variables of most value in this regard are as follows:
-
-- `DRAGONFLY_THREADS` defaults to the number of available parallelism, or
-  1 if it could not be determined. [This
-  page](https://doc.rust-lang.org/stable/std/thread/fn.available_parallelism.html)
-  explains in detail how this is calculated, but in short, it is often the
-  number of compute cores a machine has. The client will spawn this many
-  threads in a threadpool executor to perform concurrent scanning of files.
-- `DRAGONFLY_LOAD_DURATION` defaults to `60` seconds. This is the frequency
-  with which the loader thread will send an HTTP API request to the Dragonfly
-  API requesting N amount of jobs (defined by `DRAGONFLY_BULK_SIZE`).
-- `DRAGONFLY_BULK_SIZE` defaults to `20`. This is the amount of jobs the loader
-  thread will request from the API at once. Setting this too high may mean the
-  scanner threads can't keep up, but setting this too low may mean that
-  more CPU time is wasted by idling. `DRAGONFLY_MAX_SCAN_SIZE` defaults to
-- `128000000`. The maximum size of downloaded distributions, in bytes. Setting
-  this too high may cause clients with low memory to run out of memory and
-  crash, setting it too low may mean most packages are not scanned (due to
-  being above the size limit).
-
-Many of these options have disadvantages to setting these options to any
-extreme (too high or too low), so it's important to tweak it to a good middle
-ground that works best in your environment. However, we have tried our best to
-provide sensible defaults that will work reasonably efficiently: 20 jobs are
-requested from the API every 60 seconds.
+The scanner processes one package and one distribution at a time. Compressed
+downloads, expanded archives, individual scan targets, archive entry counts,
+and distributions per package are bounded independently. The defaults target
+a 512 MiB background-worker container while preserving substantial headroom
+for compiled YARA rules, ZIP metadata, allocator overhead, and filesystem
+cache.
 
 ### How it works: Detailed Breakdown
 
@@ -125,21 +106,12 @@ comprised of several "distributions" in the form of gzipped tarballs or wheels
 (which behave similarly to zip files, hence the use of the `zip` crate). Each
 distribution is comprised of a flat sequence of files (the hierarchical nature
 of the traditional file/folder system has been flatted for our use case). The
-main entry point interface to the scanner logic is via the
-`scan_all_distribution`. This loops over the download URLs of each distribution
-of the given job, and attempts to download them. The maximum size of these
-downloads, in bytes, is controlled by the `DRAGONFLY_MAX_SIZE` environment
-variable (128MB by default) Then, for each distribution downloaded, we loop
-over each file in that distribution, load it into memory, and apply the
-compiled YARA rules stored in memory against the file contents (this is done by
-the underlying C YARA library). Then, the results of each files is stored in
-a "distribution scan result" struct that represents the scan results of
-a single distribution. This process is repeated for all the distributions in
-a package, and are aggregated into a "package scan result" struct. This model
-highly reflects PyPI's model of "package -> distributions -> files". This
-process allows us to start with the download URLs of each distribution of
-a package, and end with the scan results of each file of each distribution of
-the given package.
+main entry point interface to the scanner logic is via
+`scan_all_distributions`. This loops over the download URLs sequentially,
+stages each compressed distribution on temporary disk, validates its resource
+limits, and extracts it. Files are scanned individually from disk by YARA.
+Only the highest-scoring file and unique matched rules are retained for each
+distribution.
 
 The loader thread's primary responsibility is to request a bunch of jobs from
 the API and spawn threadpool tasks on a timer. It will perform a "bulk job
@@ -170,4 +142,9 @@ they do
 | `DRAGONFLY_THREADS`                   | Available parallelism / `1`      | Attempts to auto-detect the amount of threads, or defaults to 1 if not possible |
 | `DRAGONFLY_LOAD_DURATION`             | 60                               | Seconds to wait between each API job request                                    |
 | `DRAGONFLY_BULK_SIZE`                 | 20                               | The amount of jobs to request at once                                           |
+| `DRAGONFLY_MAX_ARCHIVE_ENTRIES`       | 4096                             | Maximum number of entries in one archive                                        |
+| `DRAGONFLY_MAX_DISTRIBUTIONS`         | 32                               | Maximum number of distributions in one package                                  |
+| `DRAGONFLY_MAX_DOWNLOAD_SIZE`         | 33554432                         | Maximum compressed distribution size in bytes                                   |
+| `DRAGONFLY_MAX_EXPANDED_SIZE`         | 67108864                         | Maximum total expanded distribution size in bytes                               |
+| `DRAGONFLY_MAX_SCAN_SIZE`             | 16777216                         | Maximum individual file size passed to YARA in bytes                            |
 <!-- markdownlint-enable MD013 -->

--- a/README.md
+++ b/README.md
@@ -111,16 +111,17 @@ main entry point interface to the scanner logic is via
 stages each compressed distribution on temporary disk, validates its resource
 limits, and extracts it. Files are scanned individually from disk by YARA.
 Only the highest-scoring file and unique matched rules are retained for each
-distribution.
+distribution. After every distribution finishes, the client unions matched
+rules across the complete package, sums each unique rule's score once, and
+submits one package verdict to the API. The inspector URL identifies the
+highest-scoring file anywhere in the package.
 
-The loader thread's primary responsibility is to request a bunch of jobs from
-the API and spawn threadpool tasks on a timer. It will perform a "bulk job
-request" (`POST /jobs`) API request to retrieve N jobs from the API, where
-N can be configured via the `DRAGONFLY_BULK_SIZE` environment variable. The
-client will make these bulk requests at an interval defined by
-the`DRAGONFLY_LOAD_DURATION` environment variable. The jobs returned by the API
-endpoint will then be spawned as tasks in the threadpool. This process repeats for
-the duration of the program.
+The client requests at most one job per configured worker, up to
+`DRAGONFLY_BULK_SIZE`, and scans those packages concurrently. Each package's
+distributions and files remain sequential. The default worker count follows the
+machine's available CPU parallelism; constrained deployments can set
+`DRAGONFLY_THREADS=1` to guarantee sequential package processing. Empty and
+failed job requests are retried after `DRAGONFLY_LOAD_DURATION` seconds.
 
 The client authenticates every Dragonfly API request with a Cloudflare Access
 service token. The source code of the YARA rules is compiled (very much like
@@ -139,9 +140,9 @@ they do
 | `DRAGONFLY_BASE_URL`                  | `https://dragonfly.vipyrsec.com` | The base API URL for the mainframe server                                       |
 | `DRAGONFLY_CF_ACCESS_CLIENT_ID`       |                                  | Environment-specific Cloudflare Access service-token client ID                  |
 | `DRAGONFLY_CF_ACCESS_CLIENT_SECRET`   |                                  | Environment-specific Cloudflare Access service-token client secret              |
-| `DRAGONFLY_THREADS`                   | Available parallelism / `1`      | Attempts to auto-detect the amount of threads, or defaults to 1 if not possible |
+| `DRAGONFLY_THREADS`                   | Available parallelism / `1`      | Concurrent package workers; set to 1 for sequential constrained deployments     |
 | `DRAGONFLY_LOAD_DURATION`             | 60                               | Seconds to wait between each API job request                                    |
-| `DRAGONFLY_BULK_SIZE`                 | 20                               | The amount of jobs to request at once                                           |
+| `DRAGONFLY_BULK_SIZE`                 | 20                               | Upper bound for job request, also capped by the worker count                    |
 | `DRAGONFLY_MAX_ARCHIVE_ENTRIES`       | 4096                             | Maximum number of entries in one archive                                        |
 | `DRAGONFLY_MAX_DISTRIBUTIONS`         | 32                               | Maximum number of distributions in one package                                  |
 | `DRAGONFLY_MAX_DOWNLOAD_SIZE`         | 33554432                         | Maximum compressed distribution size in bytes                                   |

--- a/deny.toml
+++ b/deny.toml
@@ -15,7 +15,6 @@ allow = [
   "Unicode-3.0",
   "Unlicense",
   "Zlib",
-  "bzip2-1.0.6",
 ]
 
 [bans]

--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -6,6 +6,8 @@ use figment::{
 };
 use serde::{Deserialize, Serialize};
 
+const MEBIBYTE: u64 = 1024 * 1024;
+
 #[derive(Serialize, Deserialize)]
 pub struct AppConfig {
     pub base_url: String,
@@ -14,6 +16,10 @@ pub struct AppConfig {
     pub bulk_size: usize,
     pub cf_access_client_id: String,
     pub cf_access_client_secret: String,
+    pub max_archive_entries: usize,
+    pub max_distributions: usize,
+    pub max_download_size: u64,
+    pub max_expanded_size: u64,
     pub max_scan_size: u64,
 }
 
@@ -29,7 +35,11 @@ impl Default for AppConfig {
             threads: available_parallelism,
             bulk_size: 20,
             load_duration: 60,
-            max_scan_size: 1.28e+8 as u64, // 128 MB
+            max_archive_entries: 4096,
+            max_distributions: 32,
+            max_download_size: 32 * MEBIBYTE,
+            max_expanded_size: 64 * MEBIBYTE,
+            max_scan_size: 16 * MEBIBYTE,
         }
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -86,17 +86,12 @@ impl DragonflyClient {
         Ok(())
     }
 
-    pub fn bulk_get_job(&mut self, n_jobs: usize) -> reqwest::Result<Vec<Job>> {
+    pub fn bulk_get_job(&self, n_jobs: usize) -> reqwest::Result<Vec<Job>> {
         fetch_bulk_job(&self.api_client, &self.base_url, n_jobs)
     }
 
-    pub fn get_job(&mut self) -> reqwest::Result<Option<Job>> {
-        // not `slice::first` because we want to own the Job
-        self.bulk_get_job(1).map(|jobs| jobs.into_iter().nth(0))
-    }
-
     /// Send a [`crate::client::models::ScanResult`] to mainframe
-    pub fn send_result(&mut self, body: models::ScanResult) -> reqwest::Result<()> {
+    pub fn send_result(&self, body: models::ScanResult) -> reqwest::Result<()> {
         send_result(&self.api_client, &self.base_url, body)
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,14 +7,39 @@ pub use models::*;
 use tempfile::{tempdir, tempfile, TempDir};
 
 use crate::APP_CONFIG;
-use color_eyre::Result;
+use color_eyre::{
+    eyre::{bail, ensure},
+    Result,
+};
 use reqwest::{
     blocking::Client,
     header::{HeaderMap, HeaderValue},
     redirect::Policy,
     Url,
 };
-use std::io;
+use std::{
+    fs::File,
+    io::{self, Read, Seek},
+};
+
+#[derive(Clone, Copy)]
+struct ArchiveLimits {
+    entries: usize,
+    download_size: u64,
+    expanded_size: u64,
+    scan_size: u64,
+}
+
+impl ArchiveLimits {
+    fn configured() -> Self {
+        Self {
+            entries: APP_CONFIG.max_archive_entries,
+            download_size: APP_CONFIG.max_download_size,
+            expanded_size: APP_CONFIG.max_expanded_size,
+            scan_size: APP_CONFIG.max_scan_size,
+        }
+    }
+}
 
 pub struct RulesState {
     pub rules: yara::Rules,
@@ -102,23 +127,155 @@ fn build_download_http_client() -> reqwest::Result<Client> {
     Client::builder().gzip(true).build()
 }
 
-/// Download and unpack a tarball, return the [`TempDir`] containing the contents.
-fn extract_tarball<R: io::Read>(response: R) -> Result<TempDir> {
-    let mut tarball = tar::Archive::new(GzDecoder::new(response));
+fn stage_download<R: Read>(response: R, limit: u64) -> Result<File> {
+    let read_limit = limit
+        .checked_add(1)
+        .ok_or_else(|| color_eyre::eyre::eyre!("download size limit is too large"))?;
+    let mut file = tempfile()?;
+    let downloaded = io::copy(&mut response.take(read_limit), &mut file)?;
+    ensure!(
+        downloaded <= limit,
+        "compressed distribution exceeds the {limit}-byte download limit"
+    );
+    file.rewind()?;
+
+    Ok(file)
+}
+
+/// Unpack a tarball within the configured resource limits.
+fn extract_tarball(file: File, limits: ArchiveLimits) -> Result<TempDir> {
+    let mut tarball = tar::Archive::new(GzDecoder::new(file));
     let tmpdir = tempdir()?;
-    tarball.unpack(tmpdir.path())?;
+    let mut entries = 0_usize;
+    let mut expanded_size = 0_u64;
+
+    for entry in tarball.entries()? {
+        let mut entry = entry?;
+        entries = entries
+            .checked_add(1)
+            .ok_or_else(|| color_eyre::eyre::eyre!("tar entry count overflowed"))?;
+        ensure!(
+            entries <= limits.entries,
+            "tar archive exceeds the {}-entry limit",
+            limits.entries
+        );
+
+        let entry_size = entry.size();
+        ensure!(
+            entry_size <= limits.scan_size,
+            "tar entry {} is {entry_size} bytes, exceeding the {}-byte scan limit",
+            entry.path()?.display(),
+            limits.scan_size
+        );
+        expanded_size = expanded_size
+            .checked_add(entry_size)
+            .ok_or_else(|| color_eyre::eyre::eyre!("expanded tar size overflowed"))?;
+        ensure!(
+            expanded_size <= limits.expanded_size,
+            "tar archive exceeds the {}-byte expanded-size limit",
+            limits.expanded_size
+        );
+        ensure!(
+            entry.unpack_in(tmpdir.path())?,
+            "tar entry would unpack outside the temporary directory"
+        );
+    }
+
     Ok(tmpdir)
 }
 
-/// Download and extract a zip, return the [`TempDir`] containing the contents.
-fn extract_zipfile<R: io::Read>(mut response: R) -> Result<TempDir> {
-    let mut file = tempfile()?;
+fn zip_entry_count(file: &mut File) -> Result<usize> {
+    const END_HEADER_SIZE: usize = 22;
+    const MAX_COMMENT_SIZE: usize = u16::MAX as usize;
+    const SIGNATURE: [u8; 4] = [0x50, 0x4b, 0x05, 0x06];
 
-    // first write the archive to a file because `response` isn't Seek, which is needed by
-    // `zip::ZipArchive::new`
-    io::copy(&mut response, &mut file)?;
+    let file_size = file.seek(io::SeekFrom::End(0))?;
+    let tail_size = file_size.min((END_HEADER_SIZE + MAX_COMMENT_SIZE) as u64);
+    file.seek(io::SeekFrom::End(
+        -i64::try_from(tail_size).expect("ZIP footer window fits in i64"),
+    ))?;
 
+    let mut tail = vec![0_u8; usize::try_from(tail_size)?];
+    file.read_exact(&mut tail)?;
+    let Some(header_start) =
+        (0..=tail.len().saturating_sub(SIGNATURE.len()))
+            .rev()
+            .find(|&index| {
+                if tail[index..].get(..SIGNATURE.len()) != Some(&SIGNATURE) {
+                    return false;
+                }
+                let Some(comment_size) = tail
+                    .get(index + 20..index + 22)
+                    .map(|bytes| u16::from_le_bytes([bytes[0], bytes[1]]) as usize)
+                else {
+                    return false;
+                };
+                tail.len() - index == END_HEADER_SIZE + comment_size
+            })
+    else {
+        bail!("ZIP end-of-central-directory record is missing");
+    };
+    let header = &tail[header_start..];
+    let disk_number = u16::from_le_bytes([header[4], header[5]]);
+    let directory_disk = u16::from_le_bytes([header[6], header[7]]);
+    let entries_on_disk = u16::from_le_bytes([header[8], header[9]]);
+    let entries = u16::from_le_bytes([header[10], header[11]]);
+    ensure!(
+        disk_number == 0 && directory_disk == 0 && entries_on_disk == entries,
+        "multi-disk ZIP archives are not supported"
+    );
+    ensure!(
+        entries != u16::MAX,
+        "ZIP64 archives are not accepted in the constrained scanner"
+    );
+    file.rewind()?;
+
+    Ok(entries as usize)
+}
+
+/// Extract a ZIP archive within the configured resource limits.
+fn extract_zipfile(mut file: File, limits: ArchiveLimits) -> Result<TempDir> {
+    let entry_count = zip_entry_count(&mut file)?;
+    ensure!(
+        entry_count <= limits.entries,
+        "ZIP archive contains {entry_count} entries, exceeding the {}-entry limit",
+        limits.entries
+    );
     let mut zip = zip::ZipArchive::new(file)?;
+    ensure!(
+        zip.len() == entry_count,
+        "ZIP central-directory entry count changed while parsing"
+    );
+
+    let mut expanded_size = 0_u64;
+    for index in 0..zip.len() {
+        let entry = zip.by_index(index)?;
+        ensure!(
+            matches!(
+                entry.compression(),
+                zip::CompressionMethod::Stored | zip::CompressionMethod::Deflated
+            ),
+            "ZIP entry {} uses unsupported compression method {:?}",
+            entry.name(),
+            entry.compression()
+        );
+        let entry_size = entry.size();
+        ensure!(
+            entry_size <= limits.scan_size,
+            "ZIP entry {} is {entry_size} bytes, exceeding the {}-byte scan limit",
+            entry.name(),
+            limits.scan_size
+        );
+        expanded_size = expanded_size
+            .checked_add(entry_size)
+            .ok_or_else(|| color_eyre::eyre::eyre!("expanded ZIP size overflowed"))?;
+        ensure!(
+            expanded_size <= limits.expanded_size,
+            "ZIP archive exceeds the {}-byte expanded-size limit",
+            limits.expanded_size
+        );
+    }
+
     let tmpdir = tempdir()?;
     zip.extract(tmpdir.path())?;
 
@@ -126,30 +283,66 @@ fn extract_zipfile<R: io::Read>(mut response: R) -> Result<TempDir> {
 }
 
 pub fn download_distribution(http_client: &Client, download_url: Url) -> Result<TempDir> {
-    // This conversion is fast as per the docs
     let is_tarball = download_url.as_str().ends_with(".tar.gz");
-    let response = http_client.get(download_url).send()?;
+    let response = http_client.get(download_url).send()?.error_for_status()?;
+    let limits = ArchiveLimits::configured();
+    let file = stage_download(response, limits.download_size)?;
 
     if is_tarball {
-        extract_tarball(response)
+        extract_tarball(file, limits)
     } else {
-        extract_zipfile(response)
+        extract_zipfile(file, limits)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{build_api_http_client, build_download_http_client, DragonflyClient, RulesState};
+    use super::{
+        build_api_http_client, build_download_http_client, extract_tarball, extract_zipfile,
+        stage_download, ArchiveLimits, DragonflyClient, RulesState,
+    };
+    use flate2::{write::GzEncoder, Compression};
     use std::{
-        io::{Read, Write},
+        io::{Cursor, Read, Write},
         net::TcpListener,
         sync::mpsc,
         thread,
     };
     use yara::Compiler;
+    use zip::{write::SimpleFileOptions, ZipWriter};
 
     const CLIENT_ID: &str = "test-client.access";
     const CLIENT_SECRET: &str = "test-secret";
+
+    fn archive_limits() -> ArchiveLimits {
+        ArchiveLimits {
+            entries: 4,
+            download_size: 1024,
+            expanded_size: 1024,
+            scan_size: 1024,
+        }
+    }
+
+    fn build_zip(files: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut zip = ZipWriter::new(Cursor::new(Vec::new()));
+        for (name, contents) in files {
+            zip.start_file(*name, SimpleFileOptions::default()).unwrap();
+            zip.write_all(contents).unwrap();
+        }
+        zip.finish().unwrap().into_inner()
+    }
+
+    fn build_tarball(files: &[(&str, &[u8])]) -> Vec<u8> {
+        let encoder = GzEncoder::new(Vec::new(), Compression::fast());
+        let mut tarball = tar::Builder::new(encoder);
+        for (name, contents) in files {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(contents.len().try_into().unwrap());
+            header.set_cksum();
+            tarball.append_data(&mut header, name, *contents).unwrap();
+        }
+        tarball.into_inner().unwrap().finish().unwrap()
+    }
 
     fn serve_once(response: String) -> (String, mpsc::Receiver<String>) {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
@@ -235,5 +428,68 @@ mod tests {
         let source_request = source_request.recv().unwrap().to_ascii_lowercase();
         assert!(source_request.contains("\r\ncf-access-client-id:"));
         assert!(source_request.contains("\r\ncf-access-client-secret:"));
+    }
+
+    #[test]
+    fn stage_download_rejects_oversized_input() {
+        let error = stage_download(Cursor::new(vec![0_u8; 5]), 4).unwrap_err();
+
+        assert!(error.to_string().contains("4-byte download limit"));
+    }
+
+    #[test]
+    fn zip_entry_limit_is_checked_before_extraction() {
+        let bytes = build_zip(&[("one", b"1"), ("two", b"2")]);
+        let file = stage_download(Cursor::new(bytes), 1024).unwrap();
+        let limits = ArchiveLimits {
+            entries: 1,
+            ..archive_limits()
+        };
+
+        let error = extract_zipfile(file, limits).unwrap_err();
+
+        assert!(error.to_string().contains("2 entries"));
+    }
+
+    #[test]
+    fn zip_expanded_size_is_bounded() {
+        let bytes = build_zip(&[("one", b"1234"), ("two", b"5678")]);
+        let file = stage_download(Cursor::new(bytes), 1024).unwrap();
+        let limits = ArchiveLimits {
+            expanded_size: 7,
+            ..archive_limits()
+        };
+
+        let error = extract_zipfile(file, limits).unwrap_err();
+
+        assert!(error.to_string().contains("expanded-size limit"));
+    }
+
+    #[test]
+    fn zip_file_scan_size_is_bounded() {
+        let bytes = build_zip(&[("large", b"12345")]);
+        let file = stage_download(Cursor::new(bytes), 1024).unwrap();
+        let limits = ArchiveLimits {
+            scan_size: 4,
+            ..archive_limits()
+        };
+
+        let error = extract_zipfile(file, limits).unwrap_err();
+
+        assert!(error.to_string().contains("4-byte scan limit"));
+    }
+
+    #[test]
+    fn tar_expanded_size_is_bounded() {
+        let bytes = build_tarball(&[("one", b"1234"), ("two", b"5678")]);
+        let file = stage_download(Cursor::new(bytes), 1024).unwrap();
+        let limits = ArchiveLimits {
+            expanded_size: 7,
+            ..archive_limits()
+        };
+
+        let error = extract_tarball(file, limits).unwrap_err();
+
+        assert!(error.to_string().contains("expanded-size limit"));
     }
 }

--- a/src/client/models.rs
+++ b/src/client/models.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use serde::{self, Deserialize};
 use std::collections::HashMap;
 use std::fmt::Display;
-use yara::{Compiler, Rules};
+use yara::{Compiler, Rules, ScanFlags};
 
 pub type ScanResult = Result<SubmitJobResultsSuccess, SubmitJobResultsError>;
 
@@ -79,9 +79,10 @@ impl RulesResponse {
             .collect::<Vec<&str>>()
             .join("\n");
 
-        let compiled_rules = Compiler::new()?
+        let mut compiled_rules = Compiler::new()?
             .add_rules_str(&rules_str)?
             .compile_rules()?;
+        compiled_rules.set_flags(ScanFlags::FAST_MODE);
 
         Ok(compiled_rules)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use client::DragonflyClient;
 use color_eyre::eyre::{ensure, Result};
-use tracing::{error, info, span, trace, Level};
+use tracing::{error, info, span, trace, warn, Level};
 use tracing_subscriber::EnvFilter;
 
 use crate::{
@@ -17,39 +17,41 @@ use crate::{
     scanner::{scan_all_distributions, PackageScanResults},
 };
 
-fn scan_package(client: &DragonflyClient, job: Job) -> ScanResult {
+fn scan_package(client: &DragonflyClient, job: Job) -> Option<ScanResult> {
     let span = span!(Level::INFO, "Job", name = job.name, version = job.version);
     let _enter = span.enter();
 
     if job.hash != client.rules_state.hash {
-        return Err(SubmitJobResultsError {
-            name: job.name,
-            version: job.version,
-            reason: format!(
-                "job requires rules commit {}, but the scanner loaded {}",
-                job.hash, client.rules_state.hash
-            ),
-        });
+        warn!(
+            "Deferring job requiring rules commit {}; scanner loaded {}",
+            job.hash, client.rules_state.hash
+        );
+        // Do not submit a failure: mainframe will requeue the pending job after its timeout.
+        return None;
     }
 
-    match scan_all_distributions(client.download_client(), &client.rules_state.rules, &job) {
-        Ok(results) => {
-            let package_scan_results =
-                PackageScanResults::new(job.name, job.version, results, job.hash);
-            let body = package_scan_results.build_body();
+    let result =
+        match scan_all_distributions(client.download_client(), &client.rules_state.rules, &job) {
+            Ok(results) => {
+                let package_scan_results =
+                    PackageScanResults::new(job.name, job.version, results, job.hash);
+                let body = package_scan_results.build_body();
 
-            Ok(body)
-        }
-        Err(err) => Err(SubmitJobResultsError {
-            name: job.name,
-            version: job.version,
-            reason: format!("{err}"),
-        }),
-    }
+                Ok(body)
+            }
+            Err(err) => Err(SubmitJobResultsError {
+                name: job.name,
+                version: job.version,
+                reason: format!("{err}"),
+            }),
+        };
+    Some(result)
 }
 
 fn run_job(client: &DragonflyClient, job: Job) {
-    let scan_result = scan_package(client, job);
+    let Some(scan_result) = scan_package(client, job) else {
+        return;
+    };
     if let Err(err) = client.send_result(scan_result) {
         error!("Error while sending response to API: {err}");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod utils;
 use std::time::Duration;
 
 use client::DragonflyClient;
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{ensure, Result};
 use tracing::{error, info, span, trace, Level};
 use tracing_subscriber::EnvFilter;
 
@@ -20,6 +20,17 @@ use crate::{
 fn scan_package(client: &DragonflyClient, job: Job) -> ScanResult {
     let span = span!(Level::INFO, "Job", name = job.name, version = job.version);
     let _enter = span.enter();
+
+    if job.hash != client.rules_state.hash {
+        return Err(SubmitJobResultsError {
+            name: job.name,
+            version: job.version,
+            reason: format!(
+                "job requires rules commit {}, but the scanner loaded {}",
+                job.hash, client.rules_state.hash
+            ),
+        });
+    }
 
     match scan_all_distributions(client.download_client(), &client.rules_state.rules, &job) {
         Ok(results) => {
@@ -37,6 +48,28 @@ fn scan_package(client: &DragonflyClient, job: Job) -> ScanResult {
     }
 }
 
+fn run_job(client: &DragonflyClient, job: Job) {
+    let scan_result = scan_package(client, job);
+    if let Err(err) = client.send_result(scan_result) {
+        error!("Error while sending response to API: {err}");
+    }
+}
+
+fn run_jobs(client: &DragonflyClient, jobs: Vec<Job>, worker_count: usize) {
+    if worker_count == 1 {
+        for job in jobs {
+            run_job(client, job);
+        }
+        return;
+    }
+
+    std::thread::scope(|scope| {
+        for job in jobs {
+            scope.spawn(move || run_job(client, job));
+        }
+    });
+}
+
 fn main() -> Result<()> {
     color_eyre::install()?;
 
@@ -47,18 +80,30 @@ fn main() -> Result<()> {
 
     tracing_subscriber::fmt().with_env_filter(env_filter).init();
     let mut client = DragonflyClient::new()?;
+    ensure!(
+        APP_CONFIG.threads > 0,
+        "DRAGONFLY_THREADS must be greater than zero"
+    );
+    ensure!(
+        APP_CONFIG.bulk_size > 0,
+        "DRAGONFLY_BULK_SIZE must be greater than zero"
+    );
+    let batch_size = APP_CONFIG.bulk_size.min(APP_CONFIG.threads);
 
     loop {
-        info!("Fetching job");
-        match client.get_job() {
-            Ok(Some(job)) => {
-                trace!("Successfully fetched job");
+        info!("Fetching up to {batch_size} jobs");
+        match client.bulk_get_job(batch_size) {
+            Ok(jobs) if jobs.is_empty() => {
+                info!("No jobs found");
+                std::thread::sleep(Duration::from_secs(APP_CONFIG.load_duration));
+            }
+            Ok(jobs) => {
+                trace!("Successfully fetched {} jobs", jobs.len());
 
-                info!("Starting scan of {} v{}", job.name, job.version);
-                if job.hash != client.rules_state.hash {
+                if jobs.iter().any(|job| job.hash != client.rules_state.hash) {
                     info!(
-                        "Must update rules, updating from {} to {}",
-                        client.rules_state.hash, job.hash
+                        "At least one job requires rules other than {}, updating rules",
+                        client.rules_state.hash
                     );
 
                     if let Err(err) = client.update_rules() {
@@ -66,16 +111,7 @@ fn main() -> Result<()> {
                     }
                 }
 
-                let scan_result = scan_package(&client, job);
-                let http_result = client.send_result(scan_result);
-                if let Err(err) = http_result {
-                    error!("Error while sending response to API: {err}");
-                }
-            }
-
-            Ok(None) => {
-                info!("No job found");
-                std::thread::sleep(Duration::from_secs(APP_CONFIG.load_duration));
+                run_jobs(&client, jobs, APP_CONFIG.threads);
             }
 
             Err(err) => {

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -154,13 +154,9 @@ impl DistributionScanResults {
         self.matched_rules.iter().collect()
     }
 
-    /// Calculate the total score of this distribution, without counting duplicates twice
-    pub fn get_total_score(&self) -> i64 {
-        self.matched_rules.iter().map(|rule| rule.score).sum()
-    }
-
     /// Get a vector of the **unique** rule identifiers this distribution matched
-    pub fn get_matched_rule_identifiers(&self) -> Vec<&str> {
+    #[cfg(test)]
+    fn get_matched_rule_identifiers(&self) -> Vec<&str> {
         self.matched_rules
             .iter()
             .map(|rule| rule.name.as_str())
@@ -207,24 +203,29 @@ impl PackageScanResults {
         let highest_score_distribution = self
             .distribution_scan_results
             .iter()
-            .max_by_key(|distrib| distrib.get_total_score());
+            .filter(|distribution| distribution.get_most_malicious_file().is_some())
+            .max_by_key(|distribution| {
+                distribution
+                    .get_most_malicious_file()
+                    .map(FileScanResult::calculate_score)
+            });
 
-        let score = highest_score_distribution
-            .map(DistributionScanResults::get_total_score)
-            .unwrap_or_default();
+        let matched_rules = self
+            .distribution_scan_results
+            .iter()
+            .flat_map(|distribution| &distribution.matched_rules)
+            .collect::<HashSet<_>>();
+
+        let score = matched_rules.iter().map(|rule| rule.score).sum();
 
         let inspector_url =
             highest_score_distribution.and_then(DistributionScanResults::inspector_url);
 
-        // collect all rule identifiers into a HashSet to dedup, then convert to Vec
-        let rules_matched = self
-            .distribution_scan_results
+        let mut rules_matched = matched_rules
             .iter()
-            .flat_map(DistributionScanResults::get_matched_rule_identifiers)
-            .map(std::string::ToString::to_string)
-            .collect::<HashSet<String>>()
-            .into_iter()
-            .collect();
+            .map(|rule| rule.name.clone())
+            .collect::<Vec<_>>();
+        rules_matched.sort_unstable();
 
         SubmitJobResultsSuccess {
             name: self.name.clone(),
@@ -579,10 +580,16 @@ mod tests {
         let file_scan_results2 = vec![
             FileScanResult {
                 path: PathBuf::default(),
-                rules: vec![RuleScore {
-                    name: String::from("rule3"),
-                    score: 2,
-                }],
+                rules: vec![
+                    RuleScore {
+                        name: String::from("rule2"),
+                        score: 7,
+                    },
+                    RuleScore {
+                        name: String::from("rule3"),
+                        score: 2,
+                    },
+                ],
             },
             FileScanResult {
                 path: PathBuf::default(),
@@ -608,9 +615,9 @@ mod tests {
 
         assert_eq!(
             body.inspector_url,
-            Some(String::from("https://example.net/distrib1.tar.gz"))
+            Some(String::from("https://example.net/distrib2.whl"))
         );
-        assert_eq!(body.score, 12);
+        assert_eq!(body.score, 23);
         assert_eq!(
             HashSet::from([
                 "rule1".into(),

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -154,6 +154,11 @@ impl DistributionScanResults {
         self.matched_rules.iter().collect()
     }
 
+    /// Calculate the distribution score, counting each matched rule once.
+    pub fn get_total_score(&self) -> i64 {
+        self.matched_rules.iter().map(|rule| rule.score).sum()
+    }
+
     /// Get a vector of the **unique** rule identifiers this distribution matched
     #[cfg(test)]
     fn get_matched_rule_identifiers(&self) -> Vec<&str> {
@@ -203,27 +208,22 @@ impl PackageScanResults {
         let highest_score_distribution = self
             .distribution_scan_results
             .iter()
-            .filter(|distribution| distribution.get_most_malicious_file().is_some())
-            .max_by_key(|distribution| {
-                distribution
-                    .get_most_malicious_file()
-                    .map(FileScanResult::calculate_score)
-            });
+            .max_by_key(|distribution| distribution.get_total_score());
 
-        let matched_rules = self
-            .distribution_scan_results
-            .iter()
-            .flat_map(|distribution| &distribution.matched_rules)
-            .collect::<HashSet<_>>();
-
-        let score = matched_rules.iter().map(|rule| rule.score).sum();
+        let score = highest_score_distribution
+            .map(DistributionScanResults::get_total_score)
+            .unwrap_or_default();
 
         let inspector_url =
             highest_score_distribution.and_then(DistributionScanResults::inspector_url);
 
-        let mut rules_matched = matched_rules
+        let mut rules_matched = self
+            .distribution_scan_results
             .iter()
+            .flat_map(|distribution| &distribution.matched_rules)
             .map(|rule| rule.name.clone())
+            .collect::<HashSet<_>>()
+            .into_iter()
             .collect::<Vec<_>>();
         rules_matched.sort_unstable();
 
@@ -617,7 +617,7 @@ mod tests {
             body.inspector_url,
             Some(String::from("https://example.net/distrib2.whl"))
         );
-        assert_eq!(body.score, 23);
+        assert_eq!(body.score, 18);
         assert_eq!(
             HashSet::from([
                 "rule1".into(),

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::{collections::HashSet, path::Path};
 
-use color_eyre::Result;
+use color_eyre::{eyre::ensure, Result};
 use reqwest::{blocking::Client, Url};
 use tempfile::TempDir;
 use walkdir::WalkDir;
@@ -11,6 +11,7 @@ use crate::{
     client::{download_distribution, Job, SubmitJobResultsSuccess},
     exts::RuleExt,
     utils::create_inspector_url,
+    APP_CONFIG,
 };
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone)]
@@ -44,20 +45,17 @@ struct Distribution {
 }
 
 impl Distribution {
-    fn scan(&mut self, rules: &Rules) -> Result<DistributionScanResults> {
-        let mut file_scan_results: Vec<FileScanResult> = Vec::new();
+    fn scan(&mut self, rules: &Rules, max_scan_size: u64) -> Result<DistributionScanResults> {
+        let mut results = DistributionScanResults::empty(self.inspector_url.clone());
         for entry in WalkDir::new(self.dir.path())
             .into_iter()
             .filter_map(|dirent| dirent.into_iter().find(|de| de.file_type().is_file()))
         {
-            let file_scan_result = self.scan_file(entry.path(), rules)?;
-            file_scan_results.push(file_scan_result);
+            let file_scan_result = self.scan_file(entry.path(), rules, max_scan_size)?;
+            results.record(file_scan_result);
         }
 
-        Ok(DistributionScanResults::new(
-            file_scan_results,
-            self.inspector_url.clone(),
-        ))
+        Ok(results)
     }
 
     /// Scan a file given it's path, and compiled rules.
@@ -65,7 +63,13 @@ impl Distribution {
     /// # Arguments
     /// * `path` - The path of the file to scan.
     /// * `rules` - The compiled rule set to scan this file against
-    fn scan_file(&self, path: &Path, rules: &Rules) -> Result<FileScanResult> {
+    fn scan_file(&self, path: &Path, rules: &Rules, max_scan_size: u64) -> Result<FileScanResult> {
+        let file_size = path.metadata()?.len();
+        ensure!(
+            file_size <= max_scan_size,
+            "file {} is {file_size} bytes, exceeding the {max_scan_size}-byte scan limit",
+            path.display()
+        );
         let rules = rules
             .scan_file(path, 10)?
             .into_iter()
@@ -94,8 +98,11 @@ impl Distribution {
 /// Struct representing the results of a scanned distribution
 #[derive(Debug)]
 pub struct DistributionScanResults {
-    /// The scan results for each file in this distribution
-    file_scan_results: Vec<FileScanResult>,
+    /// The highest-scoring file in this distribution.
+    most_malicious_file: Option<FileScanResult>,
+
+    /// The unique rules matched across the distribution.
+    matched_rules: HashSet<RuleScore>,
 
     /// The inspector URL pointing to this distribution's base
     inspector_url: Url,
@@ -104,10 +111,32 @@ pub struct DistributionScanResults {
 impl DistributionScanResults {
     /// Create a new `DistributionScanResults` based off the results of its files and the base
     /// inspector URL for this distribution.
-    pub fn new(file_scan_results: Vec<FileScanResult>, inspector_url: Url) -> Self {
+    #[cfg(test)]
+    fn new(file_scan_results: Vec<FileScanResult>, inspector_url: Url) -> Self {
+        let mut results = Self::empty(inspector_url);
+        for file_scan_result in file_scan_results {
+            results.record(file_scan_result);
+        }
+        results
+    }
+
+    fn empty(inspector_url: Url) -> Self {
         Self {
-            file_scan_results,
+            most_malicious_file: None,
+            matched_rules: HashSet::new(),
             inspector_url,
+        }
+    }
+
+    fn record(&mut self, file_scan_result: FileScanResult) {
+        self.matched_rules
+            .extend(file_scan_result.rules.iter().cloned());
+        let should_replace = self
+            .most_malicious_file
+            .as_ref()
+            .is_none_or(|current| file_scan_result.calculate_score() >= current.calculate_score());
+        if should_replace {
+            self.most_malicious_file = Some(file_scan_result);
         }
     }
 
@@ -116,31 +145,23 @@ impl DistributionScanResults {
     /// This file with the greatest score is considered the most malicious. If multiple
     /// files have the same score, an arbitrary file is picked.
     pub fn get_most_malicious_file(&self) -> Option<&FileScanResult> {
-        self.file_scan_results
-            .iter()
-            .max_by_key(|i| i.calculate_score())
+        self.most_malicious_file.as_ref()
     }
 
     /// Get all **unique** `RuleScore` objects that were matched for this distribution
+    #[cfg(test)]
     fn get_matched_rules(&self) -> HashSet<&RuleScore> {
-        let mut rules: HashSet<&RuleScore> = HashSet::new();
-        for file_scan_result in &self.file_scan_results {
-            for rule in &file_scan_result.rules {
-                rules.insert(rule);
-            }
-        }
-
-        rules
+        self.matched_rules.iter().collect()
     }
 
     /// Calculate the total score of this distribution, without counting duplicates twice
     pub fn get_total_score(&self) -> i64 {
-        self.get_matched_rules().iter().map(|rule| rule.score).sum()
+        self.matched_rules.iter().map(|rule| rule.score).sum()
     }
 
     /// Get a vector of the **unique** rule identifiers this distribution matched
     pub fn get_matched_rule_identifiers(&self) -> Vec<&str> {
-        self.get_matched_rules()
+        self.matched_rules
             .iter()
             .map(|rule| rule.name.as_str())
             .collect()
@@ -224,6 +245,12 @@ pub fn scan_all_distributions(
     rules: &Rules,
     job: &Job,
 ) -> Result<Vec<DistributionScanResults>> {
+    ensure!(
+        job.distributions.len() <= APP_CONFIG.max_distributions,
+        "package contains {} distributions, exceeding the {}-distribution limit",
+        job.distributions.len(),
+        APP_CONFIG.max_distributions
+    );
     let mut distribution_scan_results = Vec::with_capacity(job.distributions.len());
     for distribution in &job.distributions {
         let download_url: Url = distribution.parse().unwrap();
@@ -232,7 +259,7 @@ pub fn scan_all_distributions(
         let dir = download_distribution(http_client, download_url.clone())?;
 
         let mut dist = Distribution { dir, inspector_url };
-        let distribution_scan_result = dist.scan(rules)?;
+        let distribution_scan_result = dist.scan(rules, APP_CONFIG.max_scan_size)?;
         distribution_scan_results.push(distribution_scan_result);
     }
 
@@ -243,7 +270,7 @@ pub fn scan_all_distributions(
 mod tests {
     use super::{DistributionScanResults, PackageScanResults};
     use crate::{
-        client::{ScanResultSerializer, SubmitJobResultsError, SubmitJobResultsSuccess},
+        client::{Job, ScanResultSerializer, SubmitJobResultsError, SubmitJobResultsSuccess},
         scanner::{FileScanResult, RuleScore},
     };
     use std::io::Write;
@@ -330,10 +357,10 @@ mod tests {
             },
         ];
 
-        let distribution_scan_results = DistributionScanResults {
+        let distribution_scan_results = DistributionScanResults::new(
             file_scan_results,
-            inspector_url: reqwest::Url::parse("https://example.net").unwrap(),
-        };
+            reqwest::Url::parse("https://example.net").unwrap(),
+        );
 
         assert_eq!(
             distribution_scan_results
@@ -343,6 +370,51 @@ mod tests {
                 .name,
             "rule2"
         );
+    }
+
+    #[test]
+    fn distribution_results_retain_only_the_highest_scoring_file() {
+        let file_scan_results = (0..100)
+            .map(|index| FileScanResult {
+                path: PathBuf::from(format!("file-{index}")),
+                rules: Vec::new(),
+            })
+            .collect();
+
+        let results = DistributionScanResults::new(
+            file_scan_results,
+            reqwest::Url::parse("https://example.net").unwrap(),
+        );
+
+        assert!(results.matched_rules.is_empty());
+        assert_eq!(
+            results.get_most_malicious_file().unwrap().path,
+            PathBuf::from("file-99")
+        );
+    }
+
+    #[test]
+    fn package_distribution_count_is_bounded_before_downloads() {
+        let rules = Compiler::new()
+            .unwrap()
+            .add_rules_str("rule never { condition: false }")
+            .unwrap()
+            .compile_rules()
+            .unwrap();
+        let job = Job {
+            hash: String::new(),
+            name: "large-package".into(),
+            version: "1.0.0".into(),
+            distributions: vec![
+                "https://example.com/distribution.whl".into();
+                crate::APP_CONFIG.max_distributions + 1
+            ],
+        };
+
+        let error = super::scan_all_distributions(&reqwest::blocking::Client::new(), &rules, &job)
+            .unwrap_err();
+
+        assert!(error.to_string().contains("distribution limit"));
     }
 
     #[test]
@@ -389,10 +461,10 @@ mod tests {
             },
         ];
 
-        let distribution_scan_results = DistributionScanResults {
+        let distribution_scan_results = DistributionScanResults::new(
             file_scan_results,
-            inspector_url: reqwest::Url::parse("https://example.net").unwrap(),
-        };
+            reqwest::Url::parse("https://example.net").unwrap(),
+        );
 
         let matched_rules: HashSet<RuleScore> = distribution_scan_results
             .get_matched_rules()
@@ -466,10 +538,10 @@ mod tests {
             },
         ];
 
-        let distribution_scan_results = DistributionScanResults {
+        let distribution_scan_results = DistributionScanResults::new(
             file_scan_results,
-            inspector_url: reqwest::Url::parse("https://example.net").unwrap(),
-        };
+            reqwest::Url::parse("https://example.net").unwrap(),
+        );
 
         let matched_rule_identifiers = distribution_scan_results.get_matched_rule_identifiers();
 
@@ -499,10 +571,10 @@ mod tests {
                 }],
             },
         ];
-        let distribution_scan_results1 = DistributionScanResults {
-            file_scan_results: file_scan_results1,
-            inspector_url: reqwest::Url::parse("https://example.net/distrib1.tar.gz").unwrap(),
-        };
+        let distribution_scan_results1 = DistributionScanResults::new(
+            file_scan_results1,
+            reqwest::Url::parse("https://example.net/distrib1.tar.gz").unwrap(),
+        );
 
         let file_scan_results2 = vec![
             FileScanResult {
@@ -520,10 +592,10 @@ mod tests {
                 }],
             },
         ];
-        let distribution_scan_results2 = DistributionScanResults {
-            file_scan_results: file_scan_results2,
-            inspector_url: reqwest::Url::parse("https://example.net/distrib2.whl").unwrap(),
-        };
+        let distribution_scan_results2 = DistributionScanResults::new(
+            file_scan_results2,
+            reqwest::Url::parse("https://example.net/distrib2.whl").unwrap(),
+        );
 
         let package_scan_results = PackageScanResults {
             name: String::from("remmy"),
@@ -579,7 +651,7 @@ mod tests {
             inspector_url: "https://example.com".parse().unwrap(),
         };
 
-        let result = distro.scan_file(tmpfile.path(), &rules).unwrap();
+        let result = distro.scan_file(tmpfile.path(), &rules, 1024).unwrap();
 
         assert_eq!(
             result.rules[0],
@@ -589,6 +661,27 @@ mod tests {
             }
         );
         assert_eq!(result.calculate_score(), 5);
+    }
+
+    #[test]
+    fn scan_file_rejects_files_over_the_limit_before_yara() {
+        let rules = Compiler::new()
+            .unwrap()
+            .add_rules_str("rule never { condition: false }")
+            .unwrap()
+            .compile_rules()
+            .unwrap();
+        let tempdir = tempdir().unwrap();
+        let mut tmpfile = tempfile::NamedTempFile::new_in(tempdir.path()).unwrap();
+        tmpfile.write_all(b"12345").unwrap();
+        let distro = super::Distribution {
+            dir: tempdir,
+            inspector_url: "https://example.com".parse().unwrap(),
+        };
+
+        let error = distro.scan_file(tmpfile.path(), &rules, 4).unwrap_err();
+
+        assert!(error.to_string().contains("4-byte scan limit"));
     }
 
     #[test]
@@ -634,8 +727,8 @@ mod tests {
             inspector_url: "https://example.com".parse().unwrap(),
         };
 
-        let results = distro.scan(&rules).unwrap();
+        let results = distro.scan(&rules, 1024).unwrap();
 
-        assert_eq!(results.file_scan_results.len(), 1);
+        assert_eq!(results.get_most_malicious_file().unwrap().rules.len(), 1);
     }
 }


### PR DESCRIPTION
## Summary

- bound compressed downloads, archive expansion, archive entry counts, package distribution counts, and individual YARA scan inputs
- validate ZIP metadata before central-directory allocation and restrict extraction to the codecs the scanner needs
- retain only the highest-scoring file and unique matched rules instead of every per-file result
- derive one package verdict from the highest-scoring independent distribution
- process packages concurrently according to `DRAGONFLY_THREADS` while keeping each package's distributions sequential
- defer jobs across rules-rollout races instead of scanning with mismatched rules or submitting permanent failures
- enable YARA fast mode and document conservative defaults for a 512 MiB background worker

## Why

The scanner processes untrusted package distributions whose compressed size, expanded size, entry count, and individual file sizes were previously unbounded. YARA also maps complete files while scanning, and scan results retained entries for every extracted file. In a highly memory-constrained container, archive bombs, large files, or extremely high file counts could therefore exhaust the container or node.

The new defaults deliberately treat 512 MiB as a hard ceiling:

- 32 MiB compressed distribution
- 64 MiB total expanded distribution
- 16 MiB individual scan input
- 4,096 archive entries
- 32 distributions per package

All limits remain configurable through environment variables.

The binary defaults package concurrency to the machine's available CPU
parallelism. The constrained 1-vCPU deployment is intended to set
`DRAGONFLY_THREADS=1`, guaranteeing sequential package processing without
restricting larger user-managed installations.

## Impact

Oversized or structurally excessive distributions now fail as ordinary scan errors instead of consuming unbounded memory. Downloads and extraction remain disk-backed and sequential. Compact result retention prevents packages with many harmless files from growing memory usage in proportion to file count.

ZIP support is intentionally limited to stored and deflated entries, removing unused archive codec dependencies and their decoder memory exposure.

The API still receives one result per package. Each distribution deduplicates
and sums its own matched rules, and the package score is the maximum of those
independent distribution scores. Evidence from mutually exclusive
distributions is not combined. Rule identifiers remain unioned for visibility,
and the inspector URL identifies the highest-scoring file in the winning
distribution.

## Validation

- `cargo test --all-targets --all-features --locked --no-fail-fast` — 27 passed
- strict Clippy with all warnings denied
- `prek run --all-files`
- `cargo deny check`
- `cargo doc --no-deps --document-private-items --locked`
- `cargo build --release --locked`
- `git diff --check`
