### PR TITLE
Log package scan lifecycle

### DIFF
--- a/src/client/methods.rs
+++ b/src/client/methods.rs
@@ -144,6 +144,8 @@ mod tests {
         let result = Err(SubmitJobResultsError {
             name: "example".to_owned(),
             version: "1.0.0".to_owned(),
+            attempt: 2,
+            assignment_id: "0962b72e-f197-41c3-a059-e10fdc149cce".to_owned(),
             reason: "test failure".to_owned(),
         });
 
@@ -152,6 +154,8 @@ mod tests {
         let request = request.recv().unwrap();
         assert!(request.starts_with("PUT /package HTTP/1.1\r\n"));
         assert_cloudflare_access_headers(&request);
-        assert!(request.contains(r#"{"name":"example","version":"1.0.0","reason":"test failure"}"#));
+        assert!(request.contains(
+            r#"{"name":"example","version":"1.0.0","attempt":2,"assignment_id":"0962b72e-f197-41c3-a059-e10fdc149cce","reason":"test failure"}"#
+        ));
     }
 }

--- a/src/client/models.rs
+++ b/src/client/models.rs
@@ -28,6 +28,8 @@ impl From<ScanResult> for ScanResultSerializer {
 pub struct SubmitJobResultsSuccess {
     pub name: String,
     pub version: String,
+    pub attempt: u64,
+    pub assignment_id: String,
     pub score: i64,
     pub inspector_url: Option<String>,
 
@@ -38,10 +40,12 @@ pub struct SubmitJobResultsSuccess {
     pub commit: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, PartialEq)]
 pub struct SubmitJobResultsError {
     pub name: String,
     pub version: String,
+    pub attempt: u64,
+    pub assignment_id: String,
     pub reason: String,
 }
 
@@ -55,12 +59,14 @@ impl Display for SubmitJobResultsError {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, PartialEq)]
 pub struct Job {
     pub hash: String,
     pub name: String,
     pub version: String,
     pub distributions: Vec<String>,
+    pub attempt: u64,
+    pub assignment_id: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -85,5 +91,42 @@ impl RulesResponse {
         compiled_rules.set_flags(ScanFlags::FAST_MODE);
 
         Ok(compiled_rules)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Job;
+
+    #[test]
+    fn job_deserializes_assignment_lease() {
+        let job: Job = serde_json::from_str(
+            r#"{
+                "hash": "rules-commit",
+                "name": "example",
+                "version": "1.2.3",
+                "distributions": ["https://example.com/example.whl"],
+                "attempt": 2,
+                "assignment_id": "4e3702e8-27a3-46e6-b51c-4779a94fa4ab"
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(job.attempt, 2);
+        assert_eq!(job.assignment_id, "4e3702e8-27a3-46e6-b51c-4779a94fa4ab");
+    }
+
+    #[test]
+    fn job_requires_assignment_lease() {
+        let result = serde_json::from_str::<Job>(
+            r#"{
+                "hash": "rules-commit",
+                "name": "example",
+                "version": "1.2.3",
+                "distributions": []
+            }"#,
+        );
+
+        assert!(result.is_err());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,11 +4,11 @@ mod exts;
 mod scanner;
 mod utils;
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use client::DragonflyClient;
 use color_eyre::eyre::{ensure, Result};
-use tracing::{error, info, span, trace, warn, Level};
+use tracing::{error, info, span, warn, Level};
 use tracing_subscriber::EnvFilter;
 
 use crate::{
@@ -17,12 +17,12 @@ use crate::{
     scanner::{scan_all_distributions, PackageScanResults},
 };
 
-fn scan_package(client: &DragonflyClient, job: Job) -> Option<ScanResult> {
-    let span = span!(Level::INFO, "Job", name = job.name, version = job.version);
-    let _enter = span.enter();
-
+fn scan_package(client: &DragonflyClient, job: &Job) -> Option<ScanResult> {
     if job.hash != client.rules_state.hash {
         warn!(
+            event = "scan_deferred",
+            required_rules_commit = %job.hash,
+            loaded_rules_commit = %client.rules_state.hash,
             "Deferring job requiring rules commit {}; scanner loaded {}",
             job.hash, client.rules_state.hash
         );
@@ -30,44 +30,109 @@ fn scan_package(client: &DragonflyClient, job: Job) -> Option<ScanResult> {
         return None;
     }
 
+    info!(
+        event = "scan_started",
+        distribution_count = job.distributions.len(),
+        rules_commit = %job.hash,
+        "Started package scan"
+    );
+
     let result =
-        match scan_all_distributions(client.download_client(), &client.rules_state.rules, &job) {
+        match scan_all_distributions(client.download_client(), &client.rules_state.rules, job) {
             Ok(results) => {
-                let package_scan_results =
-                    PackageScanResults::new(job.name, job.version, results, job.hash);
+                let package_scan_results = PackageScanResults::new(
+                    job.name.clone(),
+                    job.version.clone(),
+                    job.attempt,
+                    job.assignment_id.clone(),
+                    results,
+                    job.hash.clone(),
+                );
                 let body = package_scan_results.build_body();
 
                 Ok(body)
             }
             Err(err) => Err(SubmitJobResultsError {
-                name: job.name,
-                version: job.version,
+                name: job.name.clone(),
+                version: job.version.clone(),
+                attempt: job.attempt,
+                assignment_id: job.assignment_id.clone(),
                 reason: format!("{err}"),
             }),
         };
     Some(result)
 }
 
-fn run_job(client: &DragonflyClient, job: Job) {
+fn run_job(client: &DragonflyClient, job: &Job) {
+    let span = span!(
+        Level::INFO,
+        "scan_job",
+        package = %job.name,
+        version = %job.version,
+        attempt = job.attempt,
+        assignment_id = %job.assignment_id,
+    );
+    let _enter = span.enter();
+    let started_at = Instant::now();
+
     let Some(scan_result) = scan_package(client, job) else {
         return;
     };
-    if let Err(err) = client.send_result(scan_result) {
-        error!("Error while sending response to API: {err}");
+
+    let outcome = match &scan_result {
+        Ok(result) => {
+            info!(
+                event = "scan_completed",
+                elapsed_ms = started_at.elapsed().as_millis(),
+                distribution_count = job.distributions.len(),
+                score = result.score,
+                matched_rule_count = result.rules_matched.len(),
+                "Completed package scan"
+            );
+            "finished"
+        }
+        Err(result) => {
+            error!(
+                event = "scan_failed",
+                elapsed_ms = started_at.elapsed().as_millis(),
+                distribution_count = job.distributions.len(),
+                reason = %result.reason,
+                "Package scan failed"
+            );
+            "failed"
+        }
+    };
+
+    match client.send_result(scan_result) {
+        Ok(()) => info!(
+            event = "result_submitted",
+            elapsed_ms = started_at.elapsed().as_millis(),
+            outcome,
+            "Submitted package scan result"
+        ),
+        Err(err) => {
+            error!(
+                event = "result_submission_failed",
+                elapsed_ms = started_at.elapsed().as_millis(),
+                outcome,
+                error = %err,
+                "Error while sending package scan result to API"
+            );
+        }
     }
 }
 
 fn run_jobs(client: &DragonflyClient, jobs: Vec<Job>, worker_count: usize) {
     if worker_count == 1 {
         for job in jobs {
-            run_job(client, job);
+            run_job(client, &job);
         }
         return;
     }
 
     std::thread::scope(|scope| {
         for job in jobs {
-            scope.spawn(move || run_job(client, job));
+            scope.spawn(move || run_job(client, &job));
         }
     });
 }
@@ -100,7 +165,11 @@ fn main() -> Result<()> {
                 std::thread::sleep(Duration::from_secs(APP_CONFIG.load_duration));
             }
             Ok(jobs) => {
-                trace!("Successfully fetched {} jobs", jobs.len());
+                info!(
+                    event = "jobs_fetched",
+                    job_count = jobs.len(),
+                    "Fetched package scan jobs"
+                );
 
                 if jobs.iter().any(|job| job.hash != client.rules_state.hash) {
                     info!(

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -184,6 +184,8 @@ impl DistributionScanResults {
 pub struct PackageScanResults {
     pub name: String,
     pub version: String,
+    pub attempt: u64,
+    pub assignment_id: String,
     pub distribution_scan_results: Vec<DistributionScanResults>,
     pub commit_hash: String,
 }
@@ -192,12 +194,16 @@ impl PackageScanResults {
     pub fn new(
         name: String,
         version: String,
+        attempt: u64,
+        assignment_id: String,
         distribution_scan_results: Vec<DistributionScanResults>,
         commit_hash: String,
     ) -> Self {
         Self {
             name,
             version,
+            attempt,
+            assignment_id,
             distribution_scan_results,
             commit_hash,
         }
@@ -230,6 +236,8 @@ impl PackageScanResults {
         SubmitJobResultsSuccess {
             name: self.name.clone(),
             version: self.version.clone(),
+            attempt: self.attempt,
+            assignment_id: self.assignment_id.clone(),
             score,
             inspector_url,
             rules_matched,
@@ -284,6 +292,8 @@ mod tests {
         let success = SubmitJobResultsSuccess {
             name: "test".into(),
             version: "1.0.0".into(),
+            attempt: 2,
+            assignment_id: "4e3702e8-27a3-46e6-b51c-4779a94fa4ab".into(),
             score: 10,
             inspector_url: Some("inspector url".into()),
             rules_matched: vec!["abc".into(), "def".into()],
@@ -292,7 +302,7 @@ mod tests {
 
         let scan_result: ScanResultSerializer = Ok(success).into();
         let actual = serde_json::to_string(&scan_result).unwrap();
-        let expected = r#"{"name":"test","version":"1.0.0","score":10,"inspector_url":"inspector url","rules_matched":["abc","def"],"commit":"commit hash"}"#;
+        let expected = r#"{"name":"test","version":"1.0.0","attempt":2,"assignment_id":"4e3702e8-27a3-46e6-b51c-4779a94fa4ab","score":10,"inspector_url":"inspector url","rules_matched":["abc","def"],"commit":"commit hash"}"#;
 
         assert_eq!(actual, expected);
     }
@@ -302,12 +312,14 @@ mod tests {
         let error = SubmitJobResultsError {
             name: "test".into(),
             version: "1.0.0".into(),
+            attempt: 3,
+            assignment_id: "a58c83d7-0864-48da-b3d1-e7ae59ac9572".into(),
             reason: "Package too large".into(),
         };
 
         let scan_result: ScanResultSerializer = Err(error).into();
         let actual = serde_json::to_string(&scan_result).unwrap();
-        let expected = r#"{"name":"test","version":"1.0.0","reason":"Package too large"}"#;
+        let expected = r#"{"name":"test","version":"1.0.0","attempt":3,"assignment_id":"a58c83d7-0864-48da-b3d1-e7ae59ac9572","reason":"Package too large"}"#;
 
         assert_eq!(actual, expected);
     }
@@ -410,6 +422,8 @@ mod tests {
                 "https://example.com/distribution.whl".into();
                 crate::APP_CONFIG.max_distributions + 1
             ],
+            attempt: 1,
+            assignment_id: "d4d10b9b-f0ea-44dc-9d21-33c0ae9ed3c0".into(),
         };
 
         let error = super::scan_all_distributions(&reqwest::blocking::Client::new(), &rules, &job)
@@ -607,6 +621,8 @@ mod tests {
         let package_scan_results = PackageScanResults {
             name: String::from("remmy"),
             version: String::from("4.20.69"),
+            attempt: 2,
+            assignment_id: String::from("e42e7f1e-1de7-443e-ad34-3ebdff663605"),
             distribution_scan_results: vec![distribution_scan_results1, distribution_scan_results2],
             commit_hash: String::from("abc"),
         };
@@ -618,6 +634,8 @@ mod tests {
             Some(String::from("https://example.net/distrib2.whl"))
         );
         assert_eq!(body.score, 18);
+        assert_eq!(body.attempt, 2);
+        assert_eq!(body.assignment_id, "e42e7f1e-1de7-443e-ad34-3ebdff663605");
         assert_eq!(
             HashSet::from([
                 "rule1".into(),


### PR DESCRIPTION
## Summary

- echo Mainframe scan-assignment attempts and opaque assignment IDs in success and failure results
- emit package-scoped lifecycle events for scan start, completion, failure, and result submission
- include elapsed time, distribution counts, scores, matched-rule counts, and submission outcomes without logging download URLs or credentials
- promote fetched-job counts from trace to info so App Platform logs show scanner throughput

## Why

The previous client attached package name and version only to a tracing span, but emitted no info-level event on the successful scan or submission paths. That made App Platform restarts and OOM kills difficult to correlate with the package being processed. The Mainframe bounded-retry release also requires clients to echo each assignment lease after a retry.

## Validation

- `cargo test --locked --no-fail-fast` (29 passed)
- strict pedantic `cargo clippy --locked --all-targets`
- `cargo doc --locked --no-deps --document-private-items`
- `/home/rem/github/vipyrsec/.tools/bin/prek-workspace run --all-files`

No dependencies were added.

## Deployment order

Mainframe PR 404 and infrastructure PR 176 have already deployed the compatible assignment protocol to staging. After this PR merges and its image is published, the staging App Platform scanner can be updated safely.
