### PR TITLE
Add staging OpenGrep shadow worker

### DIFF
--- a/.github/workflows/opengrep-shadow-image.yaml
+++ b/.github/workflows/opengrep-shadow-image.yaml
@@ -65,7 +65,7 @@ jobs:
 
   publish:
     name: Publish staging-only shadow image
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -76,6 +76,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
+          ref: main
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2

--- a/.github/workflows/opengrep-shadow-image.yaml
+++ b/.github/workflows/opengrep-shadow-image.yaml
@@ -1,0 +1,129 @@
+---
+name: OpenGrep Shadow Image
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  IMAGE_NAME: ${{ github.repository }}-opengrep-shadow
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    name: Validate staging-only shadow image
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
+
+      - name: Extract image metadata
+        id: metadata
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: type=sha,format=long
+
+      - name: Read Rust channel
+        run: |
+          python3 <<'EOF' >"$GITHUB_ENV"
+          import tomllib
+          from pathlib import Path
+
+          rust_toolchain = tomllib.loads(Path("./rust-toolchain.toml").read_text())
+          print(f"RUST_VERSION={rust_toolchain['toolchain']['channel']}")
+          EOF
+
+      - name: Build shadow image
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        with:
+          build-args: RUST_VERSION=${{ env.RUST_VERSION }}
+          cache-from: type=gha,scope=opengrep-shadow
+          cache-to: type=gha,mode=max,scope=opengrep-shadow
+          file: Containerfile
+          labels: ${{ steps.metadata.outputs.labels }}
+          platforms: linux/amd64
+          provenance: true
+          push: false
+          sbom: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          target: opengrep-release
+
+  publish:
+    name: Publish staging-only shadow image
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write  # Authenticate the published image signature with Sigstore Fulcio.
+      packages: write  # Publish the staging-only image to GHCR on manual dispatch.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
+        with:
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+
+      - name: Extract image metadata
+        id: metadata
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: type=sha,format=long
+
+      - name: Read Rust channel
+        run: |
+          python3 <<'EOF' >"$GITHUB_ENV"
+          import tomllib
+          from pathlib import Path
+
+          rust_toolchain = tomllib.loads(Path("./rust-toolchain.toml").read_text())
+          print(f"RUST_VERSION={rust_toolchain['toolchain']['channel']}")
+          EOF
+
+      - name: Publish shadow image
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        with:
+          build-args: RUST_VERSION=${{ env.RUST_VERSION }}
+          cache-from: type=gha,scope=opengrep-shadow
+          cache-to: type=gha,mode=max,scope=opengrep-shadow
+          file: Containerfile
+          labels: ${{ steps.metadata.outputs.labels }}
+          platforms: linux/amd64
+          provenance: true
+          push: true
+          sbom: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          target: opengrep-release
+
+      - name: Sign published image
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "$REGISTRY/$IMAGE_NAME@$DIGEST"

--- a/Containerfile
+++ b/Containerfile
@@ -15,22 +15,49 @@ ARG RUST_VERSION=1.91
 ARG RUSTFLAGS="-L/usr/local/lib"
 # YARA_VERSION The version of YARA against which to link the project
 ARG YARA_VERSION=4.5.4
+# OPENGREP_VERSION The reviewed OpenGrep release used only by the shadow target
+ARG OPENGREP_VERSION=1.26.0
+# OPENGREP_SHA256 The verified linux-amd64 release digest
+ARG OPENGREP_SHA256=40c21299eeddabf743b856daa843d24f9d4a027130671cd45b3b21776fd9ab26
 
-# build-base The base for all later build stages containing common steps, like installing YARA
+# opengrep-binary is reachable only from the staging shadow image target.
+FROM rust:$RUST_VERSION-$DEBIAN_VERSION AS opengrep-binary
+ARG OPENGREP_SHA256
+ARG OPENGREP_VERSION
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN <<EOT
+#!/usr/bin/env bash
+set -euo pipefail
+
+curl --fail --location --silent --show-error \
+  "https://github.com/opengrep/opengrep/releases/download/v${OPENGREP_VERSION}/opengrep_manylinux_x86" \
+  --output /opengrep
+printf '%s  /opengrep\n' "${OPENGREP_SHA256}" > /tmp/opengrep.sha256
+sha256sum --check --strict /tmp/opengrep.sha256
+chmod 0755 /opengrep
+EOT
+
+# build-base The base for standard and shadow Rust builds, including YARA.
 FROM rust:$RUST_VERSION-$DEBIAN_VERSION AS build-base
 ARG PROJECT
 
 ARG RUSTFLAGS
 ARG YARA_VERSION
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN <<EOT
 #!/usr/bin/env bash
-set -e
+set -eu
 
 apt-get -q update
-apt-get -qy --no-install-recommends install curl libclang-dev
+apt-get -qy --no-install-recommends install \
+  'curl=8.14.1-2+deb13u4' \
+  'libclang-dev=1:19.0-63'
 rm -rf /var/lib/apt/lists/*
 EOT
+
+WORKDIR /build
 
 RUN <<EOT
 #!/usr/bin/env bash
@@ -38,8 +65,12 @@ set -euo pipefail
 
 archive_filename="yara-$YARA_VERSION.tar.gz"
 curl -sL "https://github.com/VirusTotal/yara/archive/refs/tags/v$YARA_VERSION.tar.gz" -o "$archive_filename"
-tar -xzf "$archive_filename" && cd "yara-$YARA_VERSION" && ./bootstrap.sh && ./configure && make && make install
+tar -xzf "$archive_filename"
 EOT
+
+WORKDIR /build/yara-$YARA_VERSION
+
+RUN ./bootstrap.sh && ./configure && make && make install
 
 WORKDIR /app
 COPY Cargo.toml Cargo.toml
@@ -48,6 +79,7 @@ COPY Cargo.lock Cargo.lock
 # build-debug The build stage for the debug build
 FROM build-base AS build-debug
 ARG PROJECT
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
   --mount=type=cache,id=rust-target-debug,target=/app/target \
@@ -79,6 +111,7 @@ ENTRYPOINT ["./dragonfly-client-rs"]
 # build-release The build stage for the release build
 FROM build-base AS build-release
 ARG PROJECT
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
   --mount=type=cache,id=rust-target-release,target=/app/target \
@@ -95,7 +128,8 @@ EOT
 COPY src src
 RUN --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
   --mount=type=cache,id=rust-target-release,target=/app/target \
-  cargo build --locked --release && cp "/app/target/release/$PROJECT" "/app/$PROJECT"
+  cargo build --locked --release --bin "$PROJECT" \
+  && cp "/app/target/release/$PROJECT" "/app/$PROJECT"
 
 # release The release build
 FROM gcr.io/distroless/cc-debian$DEBIAN_VERSION_NUMBER:nonroot AS release
@@ -106,3 +140,22 @@ WORKDIR /app
 COPY --from=build-release "/app/$PROJECT" "./$PROJECT"
 
 ENTRYPOINT ["./dragonfly-client-rs"]
+
+# build-opengrep-release is reachable only from the staging shadow image.
+FROM build-release AS build-opengrep-release
+
+RUN --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
+  --mount=type=cache,id=rust-target-release,target=/app/target \
+  cargo build --locked --release --bin opengrep-shadow \
+  && cp /app/target/release/opengrep-shadow /app/opengrep-shadow
+
+# opengrep-release The staging-only shadow worker. The standard release image
+# above intentionally does not contain the OpenGrep executable.
+FROM gcr.io/distroless/cc-debian$DEBIAN_VERSION_NUMBER:nonroot AS opengrep-release
+
+WORKDIR /app
+
+COPY --from=build-opengrep-release /app/opengrep-shadow ./opengrep-shadow
+COPY --from=opengrep-binary /opengrep /usr/local/bin/opengrep
+
+ENTRYPOINT ["./opengrep-shadow"]

--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -45,6 +45,11 @@ impl Default for AppConfig {
 }
 
 impl AppConfig {
+    /// Load configuration defaults, TOML files, and environment overrides.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when configured values cannot be deserialized.
     #[allow(clippy::result_large_err)]
     pub fn build() -> Result<AppConfig, figment::Error> {
         Figment::from(Serialized::defaults(AppConfig::default()))

--- a/src/bin/opengrep-shadow.rs
+++ b/src/bin/opengrep-shadow.rs
@@ -1,0 +1,118 @@
+use std::{
+    path::PathBuf,
+    time::{Duration, Instant},
+};
+
+use color_eyre::eyre::{ensure, Result};
+use dragonfly_client_rs::{
+    app_config::APP_CONFIG,
+    client::{Job, OpenGrepScanResult},
+    opengrep::OpenGrepClient,
+};
+use tracing::{error, info, warn};
+use tracing_subscriber::EnvFilter;
+
+fn run_job(client: &OpenGrepClient, job: &Job) {
+    let started_at = Instant::now();
+    let result = client.run_job(job);
+    match &result {
+        OpenGrepScanResult::Success(success) => info!(
+            event = "opengrep_scan_completed",
+            package = %job.name,
+            version = %job.version,
+            elapsed_ms = started_at.elapsed().as_millis(),
+            finding_count = success.findings.len(),
+            "Completed OpenGrep shadow scan"
+        ),
+        OpenGrepScanResult::Error(failure) => error!(
+            event = "opengrep_scan_failed",
+            package = %job.name,
+            version = %job.version,
+            elapsed_ms = started_at.elapsed().as_millis(),
+            reason = %failure.reason,
+            "OpenGrep shadow scan failed"
+        ),
+    }
+    if let Err(error) = client.submit_result(&result) {
+        error!(
+            event = "opengrep_result_submission_failed",
+            package = %job.name,
+            version = %job.version,
+            error = %error,
+            "Failed to submit OpenGrep shadow result"
+        );
+    }
+}
+
+fn run_jobs(client: &OpenGrepClient, jobs: Vec<Job>) {
+    if APP_CONFIG.threads == 1 {
+        for job in jobs {
+            run_job(client, &job);
+        }
+        return;
+    }
+    std::thread::scope(|scope| {
+        for job in jobs {
+            scope.spawn(move || run_job(client, &job));
+        }
+    });
+}
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+    let default_env_filter = EnvFilter::builder()
+        .parse("warn,opengrep_shadow=info,dragonfly_client_rs=info")
+        .unwrap();
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or(default_env_filter);
+    tracing_subscriber::fmt().with_env_filter(env_filter).init();
+
+    ensure!(
+        APP_CONFIG.threads > 0,
+        "DRAGONFLY_THREADS must be greater than zero"
+    );
+    ensure!(
+        APP_CONFIG.bulk_size > 0,
+        "DRAGONFLY_BULK_SIZE must be greater than zero"
+    );
+    let binary = std::env::var_os("OPENGREP_BIN")
+        .map_or_else(|| PathBuf::from("/usr/local/bin/opengrep"), PathBuf::from);
+    let mut client = OpenGrepClient::new(binary)?;
+    let batch_size = APP_CONFIG.bulk_size.min(APP_CONFIG.threads);
+
+    loop {
+        match client.get_jobs(batch_size) {
+            Ok(jobs) if jobs.is_empty() => {
+                info!("No OpenGrep shadow jobs found");
+                std::thread::sleep(Duration::from_secs(APP_CONFIG.load_duration));
+            }
+            Ok(jobs) => {
+                if jobs.iter().any(|job| job.hash != client.rules_hash) {
+                    if let Err(error) = client.refresh_rules() {
+                        error!(error = %error, "Failed to refresh OpenGrep rules");
+                        std::thread::sleep(Duration::from_secs(APP_CONFIG.load_duration));
+                        continue;
+                    }
+                }
+                let matching_jobs: Vec<Job> = jobs
+                    .into_iter()
+                    .filter(|job| {
+                        let matches = job.hash == client.rules_hash;
+                        if !matches {
+                            warn!(
+                                required_rules_commit = %job.hash,
+                                loaded_rules_commit = %client.rules_hash,
+                                "Deferring OpenGrep job with a mismatched rule commit"
+                            );
+                        }
+                        matches
+                    })
+                    .collect();
+                run_jobs(&client, matching_jobs);
+            }
+            Err(error) => {
+                error!(error = %error, "Failed to fetch OpenGrep shadow jobs");
+                std::thread::sleep(Duration::from_secs(APP_CONFIG.load_duration));
+            }
+        }
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -20,6 +20,7 @@ use reqwest::{
 use std::{
     fs::File,
     io::{self, Read, Seek},
+    time::Duration,
 };
 
 #[derive(Clone, Copy)]
@@ -312,8 +313,26 @@ fn extract_zipfile(mut file: File, limits: ArchiveLimits) -> Result<TempDir> {
 /// Returns an error for network failures, unsupported archives, unsafe paths,
 /// or any configured resource-limit violation.
 pub fn download_distribution(http_client: &Client, download_url: Url) -> Result<TempDir> {
+    download_distribution_with_timeout(http_client, download_url, None)
+}
+
+/// Download and safely extract one distribution with a total request timeout.
+///
+/// # Errors
+///
+/// Returns an error for network failures, timeouts, unsupported archives,
+/// unsafe paths, or any configured resource-limit violation.
+pub fn download_distribution_with_timeout(
+    http_client: &Client,
+    download_url: Url,
+    timeout: Option<Duration>,
+) -> Result<TempDir> {
     let is_tarball = download_url.as_str().ends_with(".tar.gz");
-    let response = http_client.get(download_url).send()?.error_for_status()?;
+    let mut request = http_client.get(download_url);
+    if let Some(timeout) = timeout {
+        request = request.timeout(timeout);
+    }
+    let response = request.send()?.error_for_status()?;
     let limits = ArchiveLimits::configured();
     let file = stage_download(response, limits.download_size)?;
 
@@ -327,15 +346,17 @@ pub fn download_distribution(http_client: &Client, download_url: Url) -> Result<
 #[cfg(test)]
 mod tests {
     use super::{
-        build_api_http_client, build_download_http_client, extract_tarball, extract_zipfile,
-        stage_download, ArchiveLimits, RulesState, Worker,
+        build_api_http_client, build_download_http_client, download_distribution_with_timeout,
+        extract_tarball, extract_zipfile, stage_download, ArchiveLimits, RulesState, Worker,
     };
     use flate2::{write::GzEncoder, Compression};
+    use reqwest::Url;
     use std::{
         io::{Cursor, Read, Write},
         net::TcpListener,
         sync::mpsc,
         thread,
+        time::Duration,
     };
     use yara::Compiler;
     use zip::{write::SimpleFileOptions, ZipWriter};
@@ -457,6 +478,29 @@ mod tests {
         let source_request = source_request.recv().unwrap().to_ascii_lowercase();
         assert!(source_request.contains("\r\ncf-access-client-id:"));
         assert!(source_request.contains("\r\ncf-access-client-secret:"));
+    }
+
+    #[test]
+    fn distribution_download_timeout_bounds_a_stalled_response() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request).unwrap();
+            thread::sleep(Duration::from_millis(250));
+        });
+        let url = Url::parse(&format!("http://{address}/example.tar.gz")).unwrap();
+
+        let error = download_distribution_with_timeout(
+            &build_download_http_client().unwrap(),
+            url,
+            Some(Duration::from_millis(20)),
+        )
+        .unwrap_err();
+
+        let request_error = error.downcast_ref::<reqwest::Error>().unwrap();
+        assert!(request_error.is_timeout());
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -46,15 +46,19 @@ pub struct RulesState {
     pub hash: String,
 }
 
-#[warn(clippy::module_name_repetitions)]
-pub struct DragonflyClient {
+pub struct Worker {
     api_client: Client,
     download_client: Client,
     pub rules_state: RulesState,
     base_url: String,
 }
 
-impl DragonflyClient {
+impl Worker {
+    /// Build a canonical YARA worker and load its initial corpus.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when HTTP clients, rules retrieval, or compilation fail.
     pub fn new() -> Result<Self> {
         let api_client = build_api_http_client(
             &APP_CONFIG.cf_access_client_id,
@@ -78,6 +82,10 @@ impl DragonflyClient {
     }
 
     /// Update the global ruleset. Waits for a write lock.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when rules retrieval or compilation fails.
     pub fn update_rules(&mut self) -> Result<()> {
         let response = fetch_rules(&self.api_client, &self.base_url)?;
         self.rules_state.rules = response.compile()?;
@@ -86,22 +94,37 @@ impl DragonflyClient {
         Ok(())
     }
 
+    /// Lease up to `n_jobs` canonical YARA jobs.
+    ///
+    /// # Errors
+    ///
+    /// Returns an HTTP or response-deserialization error.
     pub fn bulk_get_job(&self, n_jobs: usize) -> reqwest::Result<Vec<Job>> {
         fetch_bulk_job(&self.api_client, &self.base_url, n_jobs)
     }
 
     /// Send a [`crate::client::models::ScanResult`] to mainframe
+    ///
+    /// # Errors
+    ///
+    /// Returns an HTTP or serialization error.
     pub fn send_result(&self, body: models::ScanResult) -> reqwest::Result<()> {
         send_result(&self.api_client, &self.base_url, body)
     }
 
     /// Return the client used for uncredentialed distribution downloads.
-    pub(crate) fn download_client(&self) -> &Client {
+    #[must_use]
+    pub fn download_client(&self) -> &Client {
         &self.download_client
     }
 }
 
-fn build_api_http_client(client_id: &str, client_secret: &str) -> Result<Client> {
+/// Build the credentialed Mainframe HTTP client.
+///
+/// # Errors
+///
+/// Returns an error for invalid headers or HTTP client configuration.
+pub fn build_api_http_client(client_id: &str, client_secret: &str) -> Result<Client> {
     let mut headers = HeaderMap::new();
     headers.insert("CF-Access-Client-Id", HeaderValue::from_str(client_id)?);
 
@@ -118,7 +141,12 @@ fn build_api_http_client(client_id: &str, client_secret: &str) -> Result<Client>
         .build()?)
 }
 
-fn build_download_http_client() -> reqwest::Result<Client> {
+/// Build the uncredentialed artifact-download HTTP client.
+///
+/// # Errors
+///
+/// Returns an HTTP client configuration error.
+pub fn build_download_http_client() -> reqwest::Result<Client> {
     Client::builder().gzip(true).build()
 }
 
@@ -277,6 +305,12 @@ fn extract_zipfile(mut file: File, limits: ArchiveLimits) -> Result<TempDir> {
     Ok(tmpdir)
 }
 
+/// Download and safely extract one supported distribution archive.
+///
+/// # Errors
+///
+/// Returns an error for network failures, unsupported archives, unsafe paths,
+/// or any configured resource-limit violation.
 pub fn download_distribution(http_client: &Client, download_url: Url) -> Result<TempDir> {
     let is_tarball = download_url.as_str().ends_with(".tar.gz");
     let response = http_client.get(download_url).send()?.error_for_status()?;
@@ -294,7 +328,7 @@ pub fn download_distribution(http_client: &Client, download_url: Url) -> Result<
 mod tests {
     use super::{
         build_api_http_client, build_download_http_client, extract_tarball, extract_zipfile,
-        stage_download, ArchiveLimits, DragonflyClient, RulesState,
+        stage_download, ArchiveLimits, RulesState, Worker,
     };
     use flate2::{write::GzEncoder, Compression};
     use std::{
@@ -378,7 +412,7 @@ mod tests {
             .unwrap()
             .compile_rules()
             .unwrap();
-        let client = DragonflyClient {
+        let client = Worker {
             api_client: build_api_http_client(CLIENT_ID, CLIENT_SECRET).unwrap(),
             download_client: build_download_http_client().unwrap(),
             rules_state: RulesState {

--- a/src/client/methods.rs
+++ b/src/client/methods.rs
@@ -2,6 +2,11 @@ use super::{models, ScanResultSerializer};
 
 use reqwest::blocking::Client;
 
+/// Lease canonical YARA jobs from Mainframe.
+///
+/// # Errors
+///
+/// Returns an HTTP or response-deserialization error.
 pub fn fetch_bulk_job(
     http_client: &Client,
     base_url: &str,
@@ -15,6 +20,11 @@ pub fn fetch_bulk_job(
         .json()
 }
 
+/// Fetch the canonical YARA corpus from Mainframe.
+///
+/// # Errors
+///
+/// Returns an HTTP or response-deserialization error.
 pub fn fetch_rules(http_client: &Client, base_url: &str) -> reqwest::Result<models::RulesResponse> {
     http_client
         .get(format!("{base_url}/rules"))
@@ -23,6 +33,11 @@ pub fn fetch_rules(http_client: &Client, base_url: &str) -> reqwest::Result<mode
         .json()
 }
 
+/// Submit one canonical YARA result to Mainframe.
+///
+/// # Errors
+///
+/// Returns an HTTP or serialization error.
 pub fn send_result(
     http_client: &Client,
     base_url: &str,
@@ -38,10 +53,69 @@ pub fn send_result(
     Ok(())
 }
 
+/// Lease isolated `OpenGrep` shadow jobs from Mainframe.
+///
+/// # Errors
+///
+/// Returns an HTTP or response-deserialization error.
+pub fn fetch_opengrep_jobs(
+    http_client: &Client,
+    base_url: &str,
+    n_jobs: usize,
+) -> reqwest::Result<Vec<models::Job>> {
+    http_client
+        .post(format!("{base_url}/opengrep/jobs"))
+        .query(&[("batch", n_jobs)])
+        .send()?
+        .error_for_status()?
+        .json()
+}
+
+/// Fetch the `OpenGrep` corpus from its isolated endpoint.
+///
+/// # Errors
+///
+/// Returns an HTTP or response-deserialization error.
+pub fn fetch_opengrep_rules(
+    http_client: &Client,
+    base_url: &str,
+) -> reqwest::Result<models::OpenGrepRulesResponse> {
+    http_client
+        .get(format!("{base_url}/opengrep/rules"))
+        .send()?
+        .error_for_status()?
+        .json()
+}
+
+/// Submit one `OpenGrep` shadow result to its isolated endpoint.
+///
+/// # Errors
+///
+/// Returns an HTTP or serialization error.
+pub fn send_opengrep_result(
+    http_client: &Client,
+    base_url: &str,
+    body: &models::OpenGrepScanResult,
+) -> reqwest::Result<()> {
+    http_client
+        .put(format!("{base_url}/opengrep/package"))
+        .json(body)
+        .send()?
+        .error_for_status()?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{fetch_bulk_job, fetch_rules, send_result};
-    use crate::client::{build_api_http_client, SubmitJobResultsError};
+    use super::{
+        fetch_bulk_job, fetch_opengrep_jobs, fetch_opengrep_rules, fetch_rules,
+        send_opengrep_result, send_result,
+    };
+    use crate::client::{
+        build_api_http_client, OpenGrepScanResult, SubmitJobResultsError,
+        SubmitOpenGrepResultsSuccess,
+    };
     use std::{
         io::{Read, Write},
         net::TcpListener,
@@ -157,5 +231,42 @@ mod tests {
         assert!(request.contains(
             r#"{"name":"example","version":"1.0.0","attempt":2,"assignment_id":"0962b72e-f197-41c3-a059-e10fdc149cce","reason":"test failure"}"#
         ));
+    }
+
+    #[test]
+    fn opengrep_routes_use_the_isolated_namespace() {
+        let client = build_api_http_client(CLIENT_ID, CLIENT_SECRET).unwrap();
+        let (jobs_url, jobs_request) = serve_once("[]");
+        assert!(fetch_opengrep_jobs(&client, &jobs_url, 2)
+            .unwrap()
+            .is_empty());
+        assert!(jobs_request
+            .recv()
+            .unwrap()
+            .starts_with("POST /opengrep/jobs?batch=2 HTTP/1.1\r\n"));
+
+        let (rules_url, rules_request) =
+            serve_once(r#"{"hash":"abc123","rules":{"python/rule.yml":"rules: []"}}"#);
+        let rules = fetch_opengrep_rules(&client, &rules_url).unwrap();
+        assert_eq!(rules.hash, "abc123");
+        assert!(rules_request
+            .recv()
+            .unwrap()
+            .starts_with("GET /opengrep/rules HTTP/1.1\r\n"));
+
+        let (result_url, result_request) = serve_once("");
+        let result = OpenGrepScanResult::Success(SubmitOpenGrepResultsSuccess {
+            name: "example".to_owned(),
+            version: "1.0.0".to_owned(),
+            attempt: 1,
+            assignment_id: "0962b72e-f197-41c3-a059-e10fdc149cce".to_owned(),
+            commit: "abc123".to_owned(),
+            duration_ms: 10,
+            findings: vec![],
+        });
+        send_opengrep_result(&client, &result_url, &result).unwrap();
+        let request = result_request.recv().unwrap();
+        assert!(request.starts_with("PUT /opengrep/package HTTP/1.1\r\n"));
+        assert_cloudflare_access_headers(&request);
     }
 }

--- a/src/client/models.rs
+++ b/src/client/models.rs
@@ -75,8 +75,60 @@ pub struct RulesResponse {
     pub rules: HashMap<String, String>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct OpenGrepRulesResponse {
+    pub hash: String,
+    pub rules: HashMap<String, String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct OpenGrepFinding {
+    pub rule_id: String,
+    pub path: String,
+    pub start_line: u64,
+    pub end_line: u64,
+    pub message: String,
+    pub severity: String,
+    pub evidence: String,
+    pub confidence: String,
+    pub execution_context: String,
+    pub inspector_url: String,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+pub struct SubmitOpenGrepResultsSuccess {
+    pub name: String,
+    pub version: String,
+    pub attempt: u64,
+    pub assignment_id: String,
+    pub commit: String,
+    pub duration_ms: u64,
+    pub findings: Vec<OpenGrepFinding>,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+pub struct SubmitOpenGrepResultsError {
+    pub name: String,
+    pub version: String,
+    pub attempt: u64,
+    pub assignment_id: String,
+    pub duration_ms: u64,
+    pub reason: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub enum OpenGrepScanResult {
+    Success(SubmitOpenGrepResultsSuccess),
+    Error(SubmitOpenGrepResultsError),
+}
+
 impl RulesResponse {
     /// Compile the rules from the response
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the YARA corpus cannot be parsed or compiled.
     pub fn compile(&self) -> Result<Rules> {
         let rules_str = self
             .rules

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod app_config;
+pub mod client;
+pub mod exts;
+pub mod opengrep;
+pub mod scanner;
+pub mod utils;
+
+pub use app_config::APP_CONFIG;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,23 +1,16 @@
-mod app_config;
-mod client;
-mod exts;
-mod scanner;
-mod utils;
-
 use std::time::{Duration, Instant};
 
-use client::DragonflyClient;
 use color_eyre::eyre::{ensure, Result};
-use tracing::{error, info, span, warn, Level};
-use tracing_subscriber::EnvFilter;
-
-use crate::{
+use dragonfly_client_rs::client::Worker;
+use dragonfly_client_rs::{
     app_config::APP_CONFIG,
     client::{Job, ScanResult, SubmitJobResultsError},
     scanner::{scan_all_distributions, PackageScanResults},
 };
+use tracing::{error, info, span, warn, Level};
+use tracing_subscriber::EnvFilter;
 
-fn scan_package(client: &DragonflyClient, job: &Job) -> Option<ScanResult> {
+fn scan_package(client: &Worker, job: &Job) -> Option<ScanResult> {
     if job.hash != client.rules_state.hash {
         warn!(
             event = "scan_deferred",
@@ -63,7 +56,7 @@ fn scan_package(client: &DragonflyClient, job: &Job) -> Option<ScanResult> {
     Some(result)
 }
 
-fn run_job(client: &DragonflyClient, job: &Job) {
+fn run_job(client: &Worker, job: &Job) {
     let span = span!(
         Level::INFO,
         "scan_job",
@@ -122,7 +115,7 @@ fn run_job(client: &DragonflyClient, job: &Job) {
     }
 }
 
-fn run_jobs(client: &DragonflyClient, jobs: Vec<Job>, worker_count: usize) {
+fn run_jobs(client: &Worker, jobs: Vec<Job>, worker_count: usize) {
     if worker_count == 1 {
         for job in jobs {
             run_job(client, &job);
@@ -146,7 +139,7 @@ fn main() -> Result<()> {
     let env_filter = EnvFilter::try_from_default_env().unwrap_or(default_env_filter);
 
     tracing_subscriber::fmt().with_env_filter(env_filter).init();
-    let mut client = DragonflyClient::new()?;
+    let mut client = Worker::new()?;
     ensure!(
         APP_CONFIG.threads > 0,
         "DRAGONFLY_THREADS must be greater than zero"

--- a/src/opengrep.rs
+++ b/src/opengrep.rs
@@ -19,7 +19,7 @@ use tempfile::{tempdir, tempfile, TempDir};
 use crate::{
     app_config::APP_CONFIG,
     client::{
-        build_api_http_client, build_download_http_client, download_distribution,
+        build_api_http_client, build_download_http_client, download_distribution_with_timeout,
         fetch_opengrep_jobs, fetch_opengrep_rules, send_opengrep_result, Job, OpenGrepFinding,
         OpenGrepRulesResponse, OpenGrepScanResult, SubmitOpenGrepResultsError,
         SubmitOpenGrepResultsSuccess,
@@ -173,14 +173,27 @@ impl OpenGrepClient {
         );
         let mut findings = Vec::new();
         for distribution in &job.distributions {
+            let distribution_started_at = Instant::now();
             let download_url: Url = distribution.parse()?;
             let inspector_url = create_inspector_url(&job.name, &job.version, &download_url);
-            let directory = download_distribution(&self.download_client, download_url)?;
+            let directory = download_distribution_with_timeout(
+                &self.download_client,
+                download_url,
+                Some(SCAN_DEADLINE),
+            )?;
+            let remaining = SCAN_DEADLINE
+                .checked_sub(distribution_started_at.elapsed())
+                .ok_or_else(|| {
+                    color_eyre::eyre::eyre!(
+                        "distribution download and extraction exceeded the 60-second deadline"
+                    )
+                })?;
             let mut distribution_findings = run_opengrep(
                 &self.binary,
                 self.rules_directory.path(),
                 directory.path(),
                 &inspector_url,
+                remaining,
             )?;
             findings.append(&mut distribution_findings);
             ensure!(
@@ -245,6 +258,7 @@ fn run_opengrep(
     rules_directory: &Path,
     target_directory: &Path,
     inspector_base: &Url,
+    deadline: Duration,
 ) -> Result<Vec<OpenGrepFinding>> {
     let mut stdout_file = tempfile()?;
     let mut stderr_file = tempfile()?;
@@ -281,10 +295,17 @@ fn run_opengrep(
         if let Some(status) = child.try_wait()? {
             break status;
         }
-        if started_at.elapsed() >= SCAN_DEADLINE {
+        let output_too_large = stdout_file.metadata()?.len() > MAX_OPENGREP_OUTPUT_BYTES
+            || stderr_file.metadata()?.len() > MAX_OPENGREP_OUTPUT_BYTES;
+        if output_too_large {
             child.kill()?;
             child.wait()?;
-            bail!("OpenGrep exceeded the 60-second distribution deadline");
+            bail!("OpenGrep output exceeded {MAX_OPENGREP_OUTPUT_BYTES} bytes");
+        }
+        if started_at.elapsed() >= deadline {
+            child.kill()?;
+            child.wait()?;
+            bail!("OpenGrep exceeded the remaining distribution deadline");
         }
         thread::sleep(CHILD_POLL_INTERVAL);
     };
@@ -379,10 +400,16 @@ fn truncate(value: &str, limit: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{materialize_rules, run_opengrep, safe_relative_path, validate_staging_origin};
+    use super::{
+        materialize_rules, run_opengrep, safe_relative_path, validate_staging_origin, SCAN_DEADLINE,
+    };
     use crate::client::OpenGrepRulesResponse;
     use reqwest::Url;
-    use std::{collections::HashMap, path::Path, path::PathBuf};
+    use std::{
+        collections::HashMap,
+        path::{Path, PathBuf},
+        time::Duration,
+    };
     use tempfile::tempdir;
 
     #[test]
@@ -457,11 +484,48 @@ rules:
         std::fs::write(target.path().join("sample.py"), "exec('safe fixture')\n").unwrap();
         let inspector = Url::parse("https://inspector.example/packages/sample/").unwrap();
 
-        let findings = run_opengrep(&binary, rules.path(), target.path(), &inspector).unwrap();
+        let findings = run_opengrep(
+            &binary,
+            rules.path(),
+            target.path(),
+            &inspector,
+            SCAN_DEADLINE,
+        )
+        .unwrap();
 
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].rule_id, "python-test-exec");
         assert_eq!(findings[0].path, "sample.py");
         assert_eq!(findings[0].execution_context, "import_time");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn opengrep_is_killed_while_its_output_exceeds_the_limit() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let rules = tempdir().unwrap();
+        let target = tempdir().unwrap();
+        let binary = target.path().join("oversized-opengrep");
+        std::fs::write(
+            &binary,
+            "#!/bin/sh\ndd if=/dev/zero bs=1048576 count=5 2>/dev/null\nsleep 5\n",
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&binary).unwrap().permissions();
+        permissions.set_mode(0o700);
+        std::fs::set_permissions(&binary, permissions).unwrap();
+        let inspector = Url::parse("https://inspector.example/packages/sample/").unwrap();
+
+        let error = run_opengrep(
+            &binary,
+            rules.path(),
+            target.path(),
+            &inspector,
+            Duration::from_secs(2),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("output exceeded"));
     }
 }

--- a/src/opengrep.rs
+++ b/src/opengrep.rs
@@ -1,0 +1,467 @@
+use std::{
+    fs::{self, File},
+    io::{Read, Seek, SeekFrom},
+    path::{Component, Path, PathBuf},
+    process::{Command, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+use color_eyre::{
+    eyre::{bail, ensure, Context},
+    Result,
+};
+use reqwest::{blocking::Client, Url};
+use serde::Deserialize;
+use serde_json::Value;
+use tempfile::{tempdir, tempfile, TempDir};
+
+use crate::{
+    app_config::APP_CONFIG,
+    client::{
+        build_api_http_client, build_download_http_client, download_distribution,
+        fetch_opengrep_jobs, fetch_opengrep_rules, send_opengrep_result, Job, OpenGrepFinding,
+        OpenGrepRulesResponse, OpenGrepScanResult, SubmitOpenGrepResultsError,
+        SubmitOpenGrepResultsSuccess,
+    },
+    utils::create_inspector_url,
+};
+
+const STAGING_ORIGIN: &str = "https://dragonfly-staging.vipyrsec.com";
+const MAX_FINDINGS: usize = 500;
+const MAX_OPENGREP_OUTPUT_BYTES: u64 = 4 * 1024 * 1024;
+const SCAN_DEADLINE: Duration = Duration::from_secs(60);
+const CHILD_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+#[derive(Debug, Deserialize)]
+struct Position {
+    line: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct FindingMetadata {
+    evidence: String,
+    confidence: String,
+    execution_context: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct FindingExtra {
+    message: String,
+    severity: String,
+    metadata: FindingMetadata,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawFinding {
+    check_id: String,
+    path: PathBuf,
+    start: Position,
+    end: Position,
+    extra: FindingExtra,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenGrepDocument {
+    results: Vec<RawFinding>,
+    #[serde(default)]
+    errors: Vec<Value>,
+    #[serde(default)]
+    skipped_rules: Vec<Value>,
+}
+
+pub struct OpenGrepClient {
+    api_client: Client,
+    download_client: Client,
+    base_url: String,
+    binary: PathBuf,
+    rules_directory: TempDir,
+    pub rules_hash: String,
+}
+
+impl OpenGrepClient {
+    /// Build a staging-pinned shadow client and load its initial corpus.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the origin fence, HTTP clients, rule retrieval,
+    /// or safe rule materialization fails.
+    pub fn new(binary: PathBuf) -> Result<Self> {
+        validate_staging_origin(&APP_CONFIG.base_url)?;
+        let api_client = build_api_http_client(
+            &APP_CONFIG.cf_access_client_id,
+            &APP_CONFIG.cf_access_client_secret,
+        )?;
+        let download_client = build_download_http_client()?;
+        let response = fetch_opengrep_rules(&api_client, &APP_CONFIG.base_url)?;
+        let rules_hash = response.hash.clone();
+        let rules_directory = materialize_rules(&response)?;
+        Ok(Self {
+            api_client,
+            download_client,
+            base_url: APP_CONFIG.base_url.trim_end_matches('/').to_owned(),
+            binary,
+            rules_directory,
+            rules_hash,
+        })
+    }
+
+    /// Replace the local `OpenGrep` corpus from Mainframe.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when retrieval or safe materialization fails.
+    pub fn refresh_rules(&mut self) -> Result<()> {
+        let response = fetch_opengrep_rules(&self.api_client, &self.base_url)?;
+        let rules_directory = materialize_rules(&response)?;
+        self.rules_hash = response.hash;
+        self.rules_directory = rules_directory;
+        Ok(())
+    }
+
+    /// Lease up to `count` `OpenGrep` shadow jobs.
+    ///
+    /// # Errors
+    ///
+    /// Returns an HTTP or response-deserialization error.
+    pub fn get_jobs(&self, count: usize) -> reqwest::Result<Vec<Job>> {
+        fetch_opengrep_jobs(&self.api_client, &self.base_url, count)
+    }
+
+    /// Scan one job and convert every failure into a bounded result payload.
+    #[must_use]
+    pub fn run_job(&self, job: &Job) -> OpenGrepScanResult {
+        let started_at = Instant::now();
+        let result = self.scan_job(job);
+        let duration_ms = u64::try_from(started_at.elapsed().as_millis()).unwrap_or(u64::MAX);
+        match result {
+            Ok(findings) => OpenGrepScanResult::Success(SubmitOpenGrepResultsSuccess {
+                name: job.name.clone(),
+                version: job.version.clone(),
+                attempt: job.attempt,
+                assignment_id: job.assignment_id.clone(),
+                commit: job.hash.clone(),
+                duration_ms,
+                findings,
+            }),
+            Err(error) => OpenGrepScanResult::Error(SubmitOpenGrepResultsError {
+                name: job.name.clone(),
+                version: job.version.clone(),
+                attempt: job.attempt,
+                assignment_id: job.assignment_id.clone(),
+                duration_ms,
+                reason: truncate(&format!("{error:#}"), 2048),
+            }),
+        }
+    }
+
+    /// Submit one completed `OpenGrep` shadow result.
+    ///
+    /// # Errors
+    ///
+    /// Returns an HTTP or serialization error.
+    pub fn submit_result(&self, result: &OpenGrepScanResult) -> reqwest::Result<()> {
+        send_opengrep_result(&self.api_client, &self.base_url, result)
+    }
+
+    fn scan_job(&self, job: &Job) -> Result<Vec<OpenGrepFinding>> {
+        ensure!(
+            job.distributions.len() <= APP_CONFIG.max_distributions,
+            "package contains {} distributions, exceeding the {}-distribution limit",
+            job.distributions.len(),
+            APP_CONFIG.max_distributions
+        );
+        let mut findings = Vec::new();
+        for distribution in &job.distributions {
+            let download_url: Url = distribution.parse()?;
+            let inspector_url = create_inspector_url(&job.name, &job.version, &download_url);
+            let directory = download_distribution(&self.download_client, download_url)?;
+            let mut distribution_findings = run_opengrep(
+                &self.binary,
+                self.rules_directory.path(),
+                directory.path(),
+                &inspector_url,
+            )?;
+            findings.append(&mut distribution_findings);
+            ensure!(
+                findings.len() <= MAX_FINDINGS,
+                "OpenGrep produced more than {MAX_FINDINGS} findings"
+            );
+        }
+        Ok(findings)
+    }
+}
+
+/// Require the exact staging API origin without paths, credentials, or queries.
+///
+/// # Errors
+///
+/// Returns an error when the URL is invalid or is not the staging origin.
+pub fn validate_staging_origin(base_url: &str) -> Result<()> {
+    let parsed = Url::parse(base_url)?;
+    let expected = Url::parse(STAGING_ORIGIN)?;
+    ensure!(
+        parsed.scheme() == expected.scheme()
+            && parsed.host_str() == expected.host_str()
+            && parsed.port_or_known_default() == expected.port_or_known_default()
+            && parsed.path().trim_end_matches('/').is_empty()
+            && parsed.query().is_none()
+            && parsed.fragment().is_none()
+            && parsed.username().is_empty()
+            && parsed.password().is_none(),
+        "OpenGrep shadow worker requires the staging API origin"
+    );
+    Ok(())
+}
+
+fn materialize_rules(response: &OpenGrepRulesResponse) -> Result<TempDir> {
+    ensure!(!response.rules.is_empty(), "OpenGrep rule corpus is empty");
+    let directory = tempdir()?;
+    for (relative_path, contents) in &response.rules {
+        let relative_path = safe_relative_path(relative_path)?;
+        let destination = directory.path().join(relative_path);
+        let parent = destination
+            .parent()
+            .ok_or_else(|| color_eyre::eyre::eyre!("OpenGrep rule path has no parent"))?;
+        fs::create_dir_all(parent)?;
+        fs::write(destination, contents)?;
+    }
+    Ok(directory)
+}
+
+fn safe_relative_path(value: &str) -> Result<PathBuf> {
+    let path = Path::new(value);
+    ensure!(!path.as_os_str().is_empty(), "path must not be empty");
+    ensure!(
+        path.components()
+            .all(|component| matches!(component, Component::Normal(_))),
+        "path must contain only normal relative components"
+    );
+    Ok(path.to_path_buf())
+}
+
+fn run_opengrep(
+    binary: &Path,
+    rules_directory: &Path,
+    target_directory: &Path,
+    inspector_base: &Url,
+) -> Result<Vec<OpenGrepFinding>> {
+    let mut stdout_file = tempfile()?;
+    let mut stderr_file = tempfile()?;
+    let mut child = Command::new(binary)
+        .args([
+            "scan",
+            "--config",
+            rules_directory
+                .to_str()
+                .ok_or_else(|| color_eyre::eyre::eyre!("rule path is not UTF-8"))?,
+            "--json",
+            "--strict",
+            "--no-git-ignore",
+            "--jobs",
+            "1",
+            "--timeout",
+            "5",
+            "--max-target-bytes",
+            &APP_CONFIG.max_scan_size.to_string(),
+            target_directory
+                .to_str()
+                .ok_or_else(|| color_eyre::eyre::eyre!("target path is not UTF-8"))?,
+        ])
+        .env("HOME", "/tmp")
+        .env("XDG_CACHE_HOME", "/tmp")
+        .env("OPENGREP_ENABLE_VERSION_CHECK", "0")
+        .stdout(Stdio::from(stdout_file.try_clone()?))
+        .stderr(Stdio::from(stderr_file.try_clone()?))
+        .spawn()
+        .wrap_err("failed to start OpenGrep")?;
+
+    let started_at = Instant::now();
+    let status = loop {
+        if let Some(status) = child.try_wait()? {
+            break status;
+        }
+        if started_at.elapsed() >= SCAN_DEADLINE {
+            child.kill()?;
+            child.wait()?;
+            bail!("OpenGrep exceeded the 60-second distribution deadline");
+        }
+        thread::sleep(CHILD_POLL_INTERVAL);
+    };
+
+    let stderr = read_bounded(&mut stderr_file)?;
+    ensure!(
+        status.success(),
+        "OpenGrep exited with {status}: {}",
+        truncate(&stderr, 1024)
+    );
+    let stdout = read_bounded(&mut stdout_file)?;
+    let document: OpenGrepDocument =
+        serde_json::from_str(&stdout).wrap_err("OpenGrep returned invalid JSON")?;
+    ensure!(
+        document.errors.is_empty(),
+        "OpenGrep reported scan errors: {}",
+        serde_json::to_string(&document.errors)?
+    );
+    ensure!(
+        document.skipped_rules.is_empty(),
+        "OpenGrep skipped rules: {}",
+        serde_json::to_string(&document.skipped_rules)?
+    );
+
+    document
+        .results
+        .into_iter()
+        .map(|finding| normalize_finding(finding, target_directory, inspector_base))
+        .collect()
+}
+
+fn read_bounded(file: &mut File) -> Result<String> {
+    file.seek(SeekFrom::Start(0))?;
+    let mut bytes = Vec::new();
+    file.take(MAX_OPENGREP_OUTPUT_BYTES + 1)
+        .read_to_end(&mut bytes)?;
+    ensure!(
+        bytes.len() as u64 <= MAX_OPENGREP_OUTPUT_BYTES,
+        "OpenGrep output exceeded {MAX_OPENGREP_OUTPUT_BYTES} bytes"
+    );
+    Ok(String::from_utf8(bytes)?)
+}
+
+fn normalize_finding(
+    finding: RawFinding,
+    target_directory: &Path,
+    inspector_base: &Url,
+) -> Result<OpenGrepFinding> {
+    let relative_path = if finding.path.is_absolute() {
+        finding.path.strip_prefix(target_directory)?.to_path_buf()
+    } else {
+        finding.path
+    };
+    let relative_path = safe_relative_path(
+        relative_path
+            .to_str()
+            .ok_or_else(|| color_eyre::eyre::eyre!("finding path is not UTF-8"))?,
+    )?;
+    let path = relative_path.to_string_lossy().replace('\\', "/");
+    ensure!(path.len() <= 1024, "finding path exceeds 1024 characters");
+    ensure!(
+        finding.extra.message.len() <= 1024,
+        "finding message exceeds 1024 characters"
+    );
+    let inspector_url = format!("{}{}", inspector_base.as_str(), path);
+    ensure!(
+        inspector_url.len() <= 2048,
+        "finding inspector URL exceeds 2048 characters"
+    );
+    let rule_id = finding
+        .check_id
+        .rsplit_once('.')
+        .map_or(finding.check_id.as_str(), |(_, identifier)| identifier)
+        .to_owned();
+    Ok(OpenGrepFinding {
+        rule_id,
+        path,
+        start_line: finding.start.line,
+        end_line: finding.end.line,
+        message: finding.extra.message,
+        severity: finding.extra.severity,
+        evidence: finding.extra.metadata.evidence,
+        confidence: finding.extra.metadata.confidence,
+        execution_context: finding.extra.metadata.execution_context,
+        inspector_url,
+    })
+}
+
+fn truncate(value: &str, limit: usize) -> String {
+    value.chars().take(limit).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{materialize_rules, run_opengrep, safe_relative_path, validate_staging_origin};
+    use crate::client::OpenGrepRulesResponse;
+    use reqwest::Url;
+    use std::{collections::HashMap, path::Path, path::PathBuf};
+    use tempfile::tempdir;
+
+    #[test]
+    fn shadow_origin_is_pinned_to_staging() {
+        validate_staging_origin("https://dragonfly-staging.vipyrsec.com").unwrap();
+        validate_staging_origin("https://dragonfly-staging.vipyrsec.com/").unwrap();
+
+        for rejected in [
+            "https://dragonfly.vipyrsec.com",
+            "http://dragonfly-staging.vipyrsec.com",
+            "https://dragonfly-staging.vipyrsec.com/other",
+            "https://dragonfly-staging.vipyrsec.com?redirect=production",
+        ] {
+            assert!(validate_staging_origin(rejected).is_err());
+        }
+    }
+
+    #[test]
+    fn rule_paths_cannot_escape_the_temporary_directory() {
+        for rejected in [
+            "",
+            "/absolute.yml",
+            "../outside.yml",
+            "python/../outside.yml",
+        ] {
+            assert!(safe_relative_path(rejected).is_err());
+        }
+        assert_eq!(
+            safe_relative_path("python/payload.yml").unwrap(),
+            Path::new("python/payload.yml")
+        );
+    }
+
+    #[test]
+    fn rules_are_materialized_with_their_relative_paths() {
+        let response = OpenGrepRulesResponse {
+            hash: "commit".to_owned(),
+            rules: HashMap::from([("python/payload.yml".to_owned(), "rules: []".to_owned())]),
+        };
+
+        let directory = materialize_rules(&response).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(directory.path().join("python/payload.yml")).unwrap(),
+            "rules: []"
+        );
+    }
+
+    #[test]
+    fn installed_opengrep_matches_the_expected_json_contract() {
+        let Some(binary) = std::env::var_os("OPENGREP_BIN").map(PathBuf::from) else {
+            return;
+        };
+        let rules = tempdir().unwrap();
+        let target = tempdir().unwrap();
+        std::fs::write(
+            rules.path().join("rule.yml"),
+            r"
+rules:
+  - id: python-test-exec
+    message: Dynamic execution.
+    languages: [python]
+    severity: ERROR
+    metadata:
+      evidence: composition
+      confidence: high
+      execution_context: import_time
+    pattern: exec(...)
+",
+        )
+        .unwrap();
+        std::fs::write(target.path().join("sample.py"), "exec('safe fixture')\n").unwrap();
+        let inspector = Url::parse("https://inspector.example/packages/sample/").unwrap();
+
+        let findings = run_opengrep(&binary, rules.path(), target.path(), &inspector).unwrap();
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "python-test-exec");
+        assert_eq!(findings[0].path, "sample.py");
+        assert_eq!(findings[0].execution_context, "import_time");
+    }
+}

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -144,6 +144,7 @@ impl DistributionScanResults {
     ///
     /// This file with the greatest score is considered the most malicious. If multiple
     /// files have the same score, an arbitrary file is picked.
+    #[must_use]
     pub fn get_most_malicious_file(&self) -> Option<&FileScanResult> {
         self.most_malicious_file.as_ref()
     }
@@ -155,6 +156,7 @@ impl DistributionScanResults {
     }
 
     /// Calculate the distribution score, counting each matched rule once.
+    #[must_use]
     pub fn get_total_score(&self) -> i64 {
         self.matched_rules.iter().map(|rule| rule.score).sum()
     }
@@ -170,6 +172,7 @@ impl DistributionScanResults {
 
     /// Return the inspector URL of the most malicious file, or `None` if there is no most malicious
     /// file
+    #[must_use]
     pub fn inspector_url(&self) -> Option<String> {
         self.get_most_malicious_file().map(|file| {
             format!(
@@ -191,6 +194,7 @@ pub struct PackageScanResults {
 }
 
 impl PackageScanResults {
+    #[must_use]
     pub fn new(
         name: String,
         version: String,
@@ -249,6 +253,11 @@ impl PackageScanResults {
 /// Scan all the distributions of the given job against the given ruleset
 ///
 /// Uses the provided HTTP client to download each distribution.
+///
+/// # Errors
+///
+/// Returns an error for malformed URLs, download or archive failures, YARA
+/// failures, or any configured resource-limit violation.
 pub fn scan_all_distributions(
     http_client: &Client,
     rules: &Rules,
@@ -262,7 +271,7 @@ pub fn scan_all_distributions(
     );
     let mut distribution_scan_results = Vec::with_capacity(job.distributions.len());
     for distribution in &job.distributions {
-        let download_url: Url = distribution.parse().unwrap();
+        let download_url: Url = distribution.parse()?;
         let inspector_url = create_inspector_url(&job.name, &job.version, &download_url);
 
         let dir = download_distribution(http_client, download_url.clone())?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,14 +1,19 @@
 use reqwest::Url;
 
+/// Build an Inspector URL for one package distribution.
+///
+/// # Panics
+///
+/// Panics only if the already-absolute `download_url` cannot accept a hostname.
 #[allow(clippy::doc_markdown)] // Clippy thinks PyPI is a documentation item
-/// Turn a package `name`, `version`, and `download_url` into a PyPI Inspector URL
+#[must_use]
 pub fn create_inspector_url(name: &str, version: &str, download_url: &Url) -> Url {
     let mut download_url = download_url.clone();
     let new_path = format!(
         "project/{}/{}/{}/",
         name,
         version,
-        download_url.path().strip_prefix('/').unwrap(),
+        download_url.path().trim_start_matches('/'),
     );
 
     download_url.set_host(Some("inspector.pypi.io")).unwrap();


### PR DESCRIPTION
## Summary

- add a separate OpenGrep shadow worker binary and isolated API namespace
- reuse bounded archive extraction without executing package code
- enforce exact staging origin, scan deadlines, output limits, and rule-path containment
- publish a distinct signed/SBOM shadow image only through manual workflow dispatch
- keep the normal release image independent of the OpenGrep binary and build target

## Validation

- strict Cargo check, clippy, formatting, and complete `prek` suite
- 34 Rust tests, including real OpenGrep JSON contract validation
- hadolint and zizmor

## Deployment

The shadow image must be manually published after merge, then pinned by immutable digest in the staging-only infrastructure manifest.
