### PR TITLE
Preserve and deduplicate OpenGrep scan results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,7 +190,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core",
 ]
 
@@ -287,6 +296,15 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -301,6 +319,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -327,6 +365,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tar",
  "tempfile",
  "tracing",
@@ -493,6 +532,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1560,6 +1609,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2008,6 +2068,12 @@ name = "typed-path"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uncased"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ parking_lot = "0.12.5"
 reqwest = {version = "0.13.1", features = ["blocking", "gzip", "json", "query"]}
 serde = {version = "1.0.228", features = ["derive"]}
 serde_json = "1.0.149"
+sha2 = "0.10.9"
 tar = "0.4.44"
 tempfile = "3.24.0"
 tracing = "0.1.44"

--- a/src/bin/opengrep-shadow.rs
+++ b/src/bin/opengrep-shadow.rs
@@ -22,6 +22,7 @@ fn run_job(client: &OpenGrepClient, job: &Job) {
             version = %job.version,
             elapsed_ms = started_at.elapsed().as_millis(),
             finding_count = success.findings.len(),
+            partial = success.partial_reason.is_some(),
             "Completed OpenGrep shadow scan"
         ),
         OpenGrepScanResult::Error(failure) => error!(

--- a/src/client/methods.rs
+++ b/src/client/methods.rs
@@ -263,6 +263,7 @@ mod tests {
             commit: "abc123".to_owned(),
             duration_ms: 10,
             findings: vec![],
+            partial_reason: None,
         });
         send_opengrep_result(&client, &result_url, &result).unwrap();
         let request = result_request.recv().unwrap();

--- a/src/client/models.rs
+++ b/src/client/models.rs
@@ -104,6 +104,8 @@ pub struct SubmitOpenGrepResultsSuccess {
     pub commit: String,
     pub duration_ms: u64,
     pub findings: Vec<OpenGrepFinding>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub partial_reason: Option<String>,
 }
 
 #[derive(Debug, Serialize, PartialEq)]

--- a/src/client/models.rs
+++ b/src/client/models.rs
@@ -81,7 +81,7 @@ pub struct OpenGrepRulesResponse {
     pub rules: HashMap<String, String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct OpenGrepFinding {
     pub rule_id: String,
     pub path: String,

--- a/src/opengrep.rs
+++ b/src/opengrep.rs
@@ -5,7 +5,7 @@ use std::{
     fs::{self, File},
     io::{self, Read, Seek, SeekFrom},
     path::{Component, Path, PathBuf},
-    process::{Command, Stdio},
+    process::{Child, Command, ExitStatus, Stdio},
     thread,
     time::{Duration, Instant},
 };
@@ -37,6 +37,7 @@ const STAGING_ORIGIN: &str = "https://dragonfly-staging.vipyrsec.com";
 const MAX_FINDINGS: usize = 500;
 const MAX_OPENGREP_OUTPUT_BYTES: u64 = 4 * 1024 * 1024;
 const SCAN_DEADLINE: Duration = Duration::from_secs(60);
+const RULE_INSPECTION_DEADLINE: Duration = Duration::from_secs(10);
 const CHILD_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 #[derive(Debug, Deserialize)]
@@ -161,8 +162,8 @@ impl OpenGrepClient {
         let download_client = build_download_http_client()?;
         let response = fetch_opengrep_rules(&api_client, &APP_CONFIG.base_url)?;
         let rules_hash = response.hash.clone();
-        let content_reuse_safe = rules_allow_content_reuse(&response);
         let rules_directory = materialize_rules(&response)?;
+        let content_reuse_safe = rules_allow_content_reuse(&binary, rules_directory.path())?;
         Ok(Self {
             api_client,
             download_client,
@@ -181,8 +182,8 @@ impl OpenGrepClient {
     /// Returns an error when retrieval or safe materialization fails.
     pub fn refresh_rules(&mut self) -> Result<()> {
         let response = fetch_opengrep_rules(&self.api_client, &self.base_url)?;
-        let content_reuse_safe = rules_allow_content_reuse(&response);
         let rules_directory = materialize_rules(&response)?;
+        let content_reuse_safe = rules_allow_content_reuse(&self.binary, rules_directory.path())?;
         self.rules_hash = response.hash;
         self.rules_directory = rules_directory;
         self.content_reuse_safe = content_reuse_safe;
@@ -383,14 +384,41 @@ fn materialize_rules(response: &OpenGrepRulesResponse) -> Result<TempDir> {
     Ok(directory)
 }
 
-fn rules_allow_content_reuse(response: &OpenGrepRulesResponse) -> bool {
-    !response.rules.values().any(|contents| {
-        contents
-            .chars()
-            .filter(|character| !character.is_whitespace() && !matches!(character, '\'' | '"'))
-            .collect::<String>()
-            .contains("paths:")
-    })
+fn rules_allow_content_reuse(binary: &Path, rules_directory: &Path) -> Result<bool> {
+    let mut stdout_file = tempfile()?;
+    let mut stderr_file = tempfile()?;
+    let mut child = Command::new(binary)
+        .args([
+            "show",
+            "dump-config",
+            rules_directory
+                .to_str()
+                .ok_or_else(|| color_eyre::eyre::eyre!("rule path is not UTF-8"))?,
+        ])
+        .env("HOME", "/tmp")
+        .env("XDG_CACHE_HOME", "/tmp")
+        .env("OPENGREP_ENABLE_VERSION_CHECK", "0")
+        .stdout(Stdio::from(stdout_file.try_clone()?))
+        .stderr(Stdio::from(stderr_file.try_clone()?))
+        .spawn()
+        .wrap_err("failed to inspect OpenGrep rules")?;
+    let status = wait_for_child(
+        &mut child,
+        &stdout_file,
+        &stderr_file,
+        RULE_INSPECTION_DEADLINE,
+        "OpenGrep rule inspection exceeded its deadline",
+    )?;
+    let stderr = read_bounded(&mut stderr_file)?;
+    ensure!(
+        status.success(),
+        "OpenGrep rule inspection exited with {status}: {}",
+        truncate(&stderr, 1024)
+    );
+    let parsed_rules = read_bounded(&mut stdout_file)?;
+    let rule_count = parsed_rules.matches("Rule.id = (").count();
+    ensure!(rule_count > 0, "OpenGrep rule inspection returned no rules");
+    Ok(rule_count == parsed_rules.matches("paths = None;").count())
 }
 
 fn safe_relative_path(value: &str) -> Result<PathBuf> {
@@ -440,27 +468,13 @@ fn run_opengrep(
         .spawn()
         .wrap_err("failed to start OpenGrep")?;
 
-    let started_at = Instant::now();
-    let status = loop {
-        if let Some(status) = child.try_wait()? {
-            break status;
-        }
-        let output_too_large = stdout_file.metadata()?.len() > MAX_OPENGREP_OUTPUT_BYTES
-            || stderr_file.metadata()?.len() > MAX_OPENGREP_OUTPUT_BYTES;
-        if output_too_large {
-            child.kill()?;
-            child.wait()?;
-            bail!("OpenGrep output exceeded {MAX_OPENGREP_OUTPUT_BYTES} bytes");
-        }
-        if started_at.elapsed() >= deadline {
-            child.kill()?;
-            child.wait()?;
-            return Err(
-                ScanTimeout("OpenGrep exceeded the remaining distribution deadline").into(),
-            );
-        }
-        thread::sleep(CHILD_POLL_INTERVAL);
-    };
+    let status = wait_for_child(
+        &mut child,
+        &stdout_file,
+        &stderr_file,
+        deadline,
+        "OpenGrep exceeded the remaining distribution deadline",
+    )?;
 
     let stderr = read_bounded(&mut stderr_file)?;
     ensure!(
@@ -505,6 +519,34 @@ fn run_opengrep(
         .map(|finding| normalize_finding(finding, target_directory, inspector_base))
         .collect::<Result<Vec<_>>>()?;
     Ok(OpenGrepRun { findings, warnings })
+}
+
+fn wait_for_child(
+    child: &mut Child,
+    stdout_file: &File,
+    stderr_file: &File,
+    deadline: Duration,
+    timeout_message: &'static str,
+) -> Result<ExitStatus> {
+    let started_at = Instant::now();
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Ok(status);
+        }
+        let output_too_large = stdout_file.metadata()?.len() > MAX_OPENGREP_OUTPUT_BYTES
+            || stderr_file.metadata()?.len() > MAX_OPENGREP_OUTPUT_BYTES;
+        if output_too_large {
+            child.kill()?;
+            child.wait()?;
+            bail!("OpenGrep output exceeded {MAX_OPENGREP_OUTPUT_BYTES} bytes");
+        }
+        if started_at.elapsed() >= deadline {
+            child.kill()?;
+            child.wait()?;
+            return Err(ScanTimeout(timeout_message).into());
+        }
+        thread::sleep(CHILD_POLL_INTERVAL);
+    }
 }
 
 fn is_recoverable_scan_warning(error: &Value) -> bool {
@@ -847,32 +889,25 @@ mod tests {
     }
 
     #[test]
-    fn path_scoped_rules_disable_content_reuse() {
-        let content_only = OpenGrepRulesResponse {
-            hash: "content-only".to_owned(),
-            rules: HashMap::from([(
-                "python/content.yml".to_owned(),
-                "rules:\n  - id: content-only\n    pattern: exec(...)\n".to_owned(),
-            )]),
+    fn installed_opengrep_structurally_detects_path_scoped_rules() {
+        let Some(binary) = std::env::var_os("OPENGREP_BIN").map(PathBuf::from) else {
+            return;
         };
-        let path_scoped = OpenGrepRulesResponse {
-            hash: "path-scoped".to_owned(),
-            rules: HashMap::from([(
-                "python/path.yml".to_owned(),
-                "rules:\n  - id: path-scoped\n    paths:\n      include: [src/**]\n".to_owned(),
-            )]),
-        };
-        let quoted_path_scoped = OpenGrepRulesResponse {
-            hash: "quoted-path-scoped".to_owned(),
-            rules: HashMap::from([(
-                "python/quoted-path.yml".to_owned(),
-                "rules:\n  - id: path-scoped\n    'paths' : {include: [src/**]}\n".to_owned(),
-            )]),
-        };
+        let rules = tempdir().unwrap();
+        let rule_path = rules.path().join("rule.yml");
+        std::fs::write(
+            &rule_path,
+            "rules:\n  - id: content-only\n    message: test\n    languages: [python]\n    severity: ERROR\n    pattern: exec(...)\n",
+        )
+        .unwrap();
+        assert!(rules_allow_content_reuse(&binary, rules.path()).unwrap());
 
-        assert!(rules_allow_content_reuse(&content_only));
-        assert!(!rules_allow_content_reuse(&path_scoped));
-        assert!(!rules_allow_content_reuse(&quoted_path_scoped));
+        std::fs::write(
+            rule_path,
+            "rules:\n  - id: path-scoped\n    message: test\n    languages: [python]\n    severity: ERROR\n    'paths' : {include: [src/**]}\n    pattern: exec(...)\n",
+        )
+        .unwrap();
+        assert!(!rules_allow_content_reuse(&binary, rules.path()).unwrap());
     }
 
     #[test]

--- a/src/opengrep.rs
+++ b/src/opengrep.rs
@@ -1,6 +1,9 @@
 use std::{
+    collections::{hash_map::DefaultHasher, HashMap},
+    error::Error as StdError,
     fs::{self, File},
-    io::{Read, Seek, SeekFrom},
+    hash::{Hash, Hasher},
+    io::{self, Read, Seek, SeekFrom},
     path::{Component, Path, PathBuf},
     process::{Command, Stdio},
     thread,
@@ -15,7 +18,8 @@ use reqwest::{blocking::Client, Url};
 use serde::Deserialize;
 use serde_json::Value;
 use tempfile::{tempdir, tempfile, TempDir};
-use tracing::warn;
+use tracing::{info, warn};
+use walkdir::WalkDir;
 
 use crate::{
     app_config::APP_CONFIG,
@@ -69,6 +73,29 @@ struct OpenGrepDocument {
     errors: Vec<Value>,
     #[serde(default)]
     skipped_rules: Vec<Value>,
+}
+
+#[derive(Debug)]
+struct ScanTimeout(&'static str);
+
+impl std::fmt::Display for ScanTimeout {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.0)
+    }
+}
+
+impl StdError for ScanTimeout {}
+
+#[derive(Debug)]
+struct OpenGrepRun {
+    findings: Vec<OpenGrepFinding>,
+    warnings: Vec<String>,
+}
+
+#[derive(Debug)]
+struct ScanJobOutcome {
+    findings: Vec<OpenGrepFinding>,
+    partial_reason: Option<String>,
 }
 
 pub struct OpenGrepClient {
@@ -136,14 +163,15 @@ impl OpenGrepClient {
         let result = self.scan_job(job);
         let duration_ms = u64::try_from(started_at.elapsed().as_millis()).unwrap_or(u64::MAX);
         match result {
-            Ok(findings) => OpenGrepScanResult::Success(SubmitOpenGrepResultsSuccess {
+            Ok(outcome) => OpenGrepScanResult::Success(SubmitOpenGrepResultsSuccess {
                 name: job.name.clone(),
                 version: job.version.clone(),
                 attempt: job.attempt,
                 assignment_id: job.assignment_id.clone(),
                 commit: job.hash.clone(),
                 duration_ms,
-                findings,
+                findings: outcome.findings,
+                partial_reason: outcome.partial_reason,
             }),
             Err(error) => OpenGrepScanResult::Error(SubmitOpenGrepResultsError {
                 name: job.name.clone(),
@@ -165,7 +193,7 @@ impl OpenGrepClient {
         send_opengrep_result(&self.api_client, &self.base_url, result)
     }
 
-    fn scan_job(&self, job: &Job) -> Result<Vec<OpenGrepFinding>> {
+    fn scan_job(&self, job: &Job) -> Result<ScanJobOutcome> {
         ensure!(
             job.distributions.len() <= APP_CONFIG.max_distributions,
             "package contains {} distributions, exceeding the {}-distribution limit",
@@ -173,36 +201,67 @@ impl OpenGrepClient {
             APP_CONFIG.max_distributions
         );
         let mut findings = Vec::new();
+        let mut warnings = Vec::new();
         for distribution in &job.distributions {
             let distribution_started_at = Instant::now();
             let download_url: Url = distribution.parse()?;
             let inspector_url = create_inspector_url(&job.name, &job.version, &download_url);
-            let directory = download_distribution_with_timeout(
+            let directory = match download_distribution_with_timeout(
                 &self.download_client,
                 download_url,
                 Some(SCAN_DEADLINE),
-            )?;
-            let remaining = SCAN_DEADLINE
-                .checked_sub(distribution_started_at.elapsed())
-                .ok_or_else(|| {
-                    color_eyre::eyre::eyre!(
-                        "distribution download and extraction exceeded the 60-second deadline"
-                    )
-                })?;
-            let mut distribution_findings = run_opengrep(
+            ) {
+                Ok(directory) => directory,
+                Err(error) if is_timeout_error(&error) => {
+                    warnings.push(format!(
+                        "Timed out downloading or extracting distribution {distribution}"
+                    ));
+                    break;
+                }
+                Err(error) => return Err(error),
+            };
+            let Some(remaining) = SCAN_DEADLINE.checked_sub(distribution_started_at.elapsed())
+            else {
+                warnings.push(format!(
+                    "Timed out downloading or extracting distribution {distribution}"
+                ));
+                break;
+            };
+            let deduplicated_files = deduplicate_target_files(directory.path())?;
+            if deduplicated_files > 0 {
+                info!(
+                    package = %job.name,
+                    version = %job.version,
+                    deduplicated_files,
+                    "Removed duplicate files before OpenGrep scan"
+                );
+            }
+            let distribution_run = match run_opengrep(
                 &self.binary,
                 self.rules_directory.path(),
                 directory.path(),
                 &inspector_url,
                 remaining,
-            )?;
-            findings.append(&mut distribution_findings);
+            ) {
+                Ok(run) => run,
+                Err(error) if is_timeout_error(&error) => {
+                    warnings.push(format!("Timed out scanning distribution {distribution}"));
+                    break;
+                }
+                Err(error) => return Err(error),
+            };
+            findings.extend(distribution_run.findings);
+            warnings.extend(distribution_run.warnings);
             ensure!(
                 findings.len() <= MAX_FINDINGS,
                 "OpenGrep produced more than {MAX_FINDINGS} findings"
             );
         }
-        Ok(findings)
+        let partial_reason = (!warnings.is_empty()).then(|| truncate(&warnings.join("; "), 2048));
+        Ok(ScanJobOutcome {
+            findings,
+            partial_reason,
+        })
     }
 }
 
@@ -260,7 +319,7 @@ fn run_opengrep(
     target_directory: &Path,
     inspector_base: &Url,
     deadline: Duration,
-) -> Result<Vec<OpenGrepFinding>> {
+) -> Result<OpenGrepRun> {
     let mut stdout_file = tempfile()?;
     let mut stderr_file = tempfile()?;
     let mut child = Command::new(binary)
@@ -305,7 +364,9 @@ fn run_opengrep(
         if started_at.elapsed() >= deadline {
             child.kill()?;
             child.wait()?;
-            bail!("OpenGrep exceeded the remaining distribution deadline");
+            return Err(
+                ScanTimeout("OpenGrep exceeded the remaining distribution deadline").into(),
+            );
         }
         thread::sleep(CHILD_POLL_INTERVAL);
     };
@@ -322,17 +383,23 @@ fn run_opengrep(
     let unexpected_errors: Vec<&Value> = document
         .errors
         .iter()
-        .filter(|error| !is_partial_parse_warning(error))
+        .filter(|error| !is_recoverable_scan_warning(error))
         .collect();
     ensure!(
         unexpected_errors.is_empty(),
         "OpenGrep reported scan errors: {}",
         serde_json::to_string(&unexpected_errors)?
     );
-    if !document.errors.is_empty() {
+    let warnings = document
+        .errors
+        .iter()
+        .filter(|error| is_recoverable_scan_warning(error))
+        .map(describe_recoverable_scan_warning)
+        .collect::<Vec<_>>();
+    if !warnings.is_empty() {
         warn!(
-            partial_parse_errors = document.errors.len(),
-            "OpenGrep partially parsed target files; preserving valid findings"
+            recoverable_scan_warnings = warnings.len(),
+            "OpenGrep reported recoverable scan warnings; preserving valid findings"
         );
     }
     ensure!(
@@ -341,21 +408,127 @@ fn run_opengrep(
         serde_json::to_string(&document.skipped_rules)?
     );
 
-    document
+    let findings = document
         .results
         .into_iter()
         .map(|finding| normalize_finding(finding, target_directory, inspector_base))
-        .collect()
+        .collect::<Result<Vec<_>>>()?;
+    Ok(OpenGrepRun { findings, warnings })
 }
 
-fn is_partial_parse_warning(error: &Value) -> bool {
-    error.get("level").and_then(Value::as_str) == Some("warn")
-        && error
+fn is_recoverable_scan_warning(error: &Value) -> bool {
+    if error.get("level").and_then(Value::as_str) != Some("warn") {
+        return false;
+    }
+    error.get("type").and_then(Value::as_str) == Some("Timeout")
+        || error
             .get("type")
             .and_then(Value::as_array)
             .and_then(|kind| kind.first())
             .and_then(Value::as_str)
             == Some("PartialParsing")
+}
+
+fn describe_recoverable_scan_warning(error: &Value) -> String {
+    if error.get("type").and_then(Value::as_str) == Some("Timeout") {
+        return error.get("rule_id").and_then(Value::as_str).map_or_else(
+            || "OpenGrep rule timed out".to_owned(),
+            |rule_id| {
+                let rule_id = rule_id
+                    .rsplit_once('.')
+                    .map_or(rule_id, |(_, identifier)| identifier);
+                format!("OpenGrep rule {} timed out", truncate(rule_id, 200))
+            },
+        );
+    }
+    let path = error
+        .get("path")
+        .and_then(Value::as_str)
+        .map_or("a target file", |path| {
+            path.rsplit('/').next().unwrap_or(path)
+        });
+    format!("OpenGrep partially parsed {}", truncate(path, 256))
+}
+
+fn is_timeout_error(error: &color_eyre::Report) -> bool {
+    error.chain().any(|source| {
+        source.downcast_ref::<ScanTimeout>().is_some()
+            || source
+                .downcast_ref::<reqwest::Error>()
+                .is_some_and(reqwest::Error::is_timeout)
+            || source
+                .downcast_ref::<io::Error>()
+                .is_some_and(|error| error.kind() == io::ErrorKind::TimedOut)
+    })
+}
+
+fn deduplicate_target_files(target_directory: &Path) -> Result<usize> {
+    let mut paths = WalkDir::new(target_directory)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(|entry| match entry {
+            Ok(entry) if entry.file_type().is_file() => Some(Ok(entry.into_path())),
+            Ok(_) => None,
+            Err(error) => Some(Err(error)),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    paths.sort_unstable();
+
+    let mut files_by_hash: HashMap<(u64, u64), Vec<PathBuf>> = HashMap::new();
+    let mut duplicate_count = 0;
+    for path in paths {
+        let fingerprint = hash_file(&path)?;
+        let candidates = files_by_hash.entry(fingerprint).or_default();
+        let mut duplicate = false;
+        for candidate in candidates.iter() {
+            if files_equal(candidate, &path)? {
+                duplicate = true;
+                break;
+            }
+        }
+        if duplicate {
+            fs::remove_file(path)?;
+            duplicate_count += 1;
+        } else {
+            candidates.push(path);
+        }
+    }
+    Ok(duplicate_count)
+}
+
+fn hash_file(path: &Path) -> Result<(u64, u64)> {
+    let mut file = File::open(path)?;
+    let length = file.metadata()?.len();
+    let mut hasher = DefaultHasher::new();
+    let mut buffer = [0_u8; 8192];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        buffer[..read].hash(&mut hasher);
+    }
+    Ok((length, hasher.finish()))
+}
+
+fn files_equal(first: &Path, second: &Path) -> Result<bool> {
+    let mut first = File::open(first)?;
+    let mut second = File::open(second)?;
+    let mut first_buffer = [0_u8; 8192];
+    let mut second_buffer = [0_u8; 8192];
+    loop {
+        let first_read = first.read(&mut first_buffer)?;
+        let second_read = second.read(&mut second_buffer)?;
+        if first_read != second_read {
+            return Ok(false);
+        }
+        if first_read == 0 {
+            return Ok(true);
+        }
+        if first_buffer[..first_read] != second_buffer[..second_read] {
+            return Ok(false);
+        }
+    }
 }
 
 fn read_bounded(file: &mut File) -> Result<String> {
@@ -422,7 +595,8 @@ fn truncate(value: &str, limit: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        materialize_rules, run_opengrep, safe_relative_path, validate_staging_origin, SCAN_DEADLINE,
+        deduplicate_target_files, materialize_rules, run_opengrep, safe_relative_path,
+        validate_staging_origin, SCAN_DEADLINE,
     };
     use crate::client::OpenGrepRulesResponse;
     use reqwest::Url;
@@ -505,7 +679,7 @@ rules:
         std::fs::write(target.path().join("sample.py"), "exec('safe fixture')\n").unwrap();
         let inspector = Url::parse("https://inspector.example/packages/sample/").unwrap();
 
-        let findings = run_opengrep(
+        let run = run_opengrep(
             &binary,
             rules.path(),
             target.path(),
@@ -514,10 +688,11 @@ rules:
         )
         .unwrap();
 
-        assert_eq!(findings.len(), 1);
-        assert_eq!(findings[0].rule_id, "python-test-exec");
-        assert_eq!(findings[0].path, "sample.py");
-        assert_eq!(findings[0].execution_context, "import_time");
+        assert_eq!(run.findings.len(), 1);
+        assert_eq!(run.findings[0].rule_id, "python-test-exec");
+        assert_eq!(run.findings[0].path, "sample.py");
+        assert_eq!(run.findings[0].execution_context, "import_time");
+        assert!(run.warnings.is_empty());
     }
 
     #[cfg(unix)]
@@ -569,7 +744,7 @@ printf '%s' '{
         std::fs::set_permissions(&binary, permissions).unwrap();
         let inspector = Url::parse("https://inspector.example/packages/sample/").unwrap();
 
-        let findings = run_opengrep(
+        let run = run_opengrep(
             &binary,
             rules.path(),
             target.path(),
@@ -578,13 +753,14 @@ printf '%s' '{
         )
         .unwrap();
 
-        assert_eq!(findings.len(), 1);
-        assert_eq!(findings[0].rule_id, "python-test-exec");
+        assert_eq!(run.findings.len(), 1);
+        assert_eq!(run.findings[0].rule_id, "python-test-exec");
+        assert_eq!(run.warnings.len(), 1);
     }
 
     #[cfg(unix)]
     #[test]
-    fn non_parse_scan_errors_remain_fatal() {
+    fn rule_timeouts_preserve_valid_findings() {
         use std::os::unix::fs::PermissionsExt;
 
         let rules = tempdir().unwrap();
@@ -594,7 +770,21 @@ printf '%s' '{
             &binary,
             r#"#!/bin/sh
 printf '%s' '{
-  "results": [],
+  "results": [{
+    "check_id": "python-test-exec",
+    "path": "sample.py",
+    "start": {"line": 1},
+    "end": {"line": 1},
+    "extra": {
+      "message": "Dynamic execution.",
+      "severity": "ERROR",
+      "metadata": {
+        "evidence": "composition",
+        "confidence": "high",
+        "execution_context": "import_time"
+      }
+    }
+  }],
   "errors": [{
     "code": 2,
     "level": "warn",
@@ -611,16 +801,33 @@ printf '%s' '{
         std::fs::set_permissions(&binary, permissions).unwrap();
         let inspector = Url::parse("https://inspector.example/packages/sample/").unwrap();
 
-        let error = run_opengrep(
+        let run = run_opengrep(
             &binary,
             rules.path(),
             target.path(),
             &inspector,
             SCAN_DEADLINE,
         )
-        .unwrap_err();
+        .unwrap();
 
-        assert!(error.to_string().contains("reported scan errors"));
+        assert_eq!(run.findings.len(), 1);
+        assert_eq!(run.warnings.len(), 1);
+        assert_eq!(run.warnings[0], "OpenGrep rule timed out");
+    }
+
+    #[test]
+    fn duplicate_target_files_are_removed_after_content_comparison() {
+        let target = tempdir().unwrap();
+        let nested = target.path().join("nested");
+        std::fs::create_dir(&nested).unwrap();
+        std::fs::write(target.path().join("first.py"), "print('same')\n").unwrap();
+        std::fs::write(nested.join("duplicate.py"), "print('same')\n").unwrap();
+        std::fs::write(target.path().join("different.py"), "print('diff')\n").unwrap();
+
+        assert_eq!(deduplicate_target_files(target.path()).unwrap(), 1);
+        assert!(target.path().join("first.py").exists());
+        assert!(!nested.join("duplicate.py").exists());
+        assert!(target.path().join("different.py").exists());
     }
 
     #[cfg(unix)]

--- a/src/opengrep.rs
+++ b/src/opengrep.rs
@@ -1,8 +1,8 @@
 use std::{
-    collections::{hash_map::DefaultHasher, HashMap},
+    collections::HashMap,
     error::Error as StdError,
+    ffi::OsString,
     fs::{self, File},
-    hash::{Hash, Hasher},
     io::{self, Read, Seek, SeekFrom},
     path::{Component, Path, PathBuf},
     process::{Command, Stdio},
@@ -17,6 +17,7 @@ use color_eyre::{
 use reqwest::{blocking::Client, Url};
 use serde::Deserialize;
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use tempfile::{tempdir, tempfile, TempDir};
 use tracing::{info, warn};
 use walkdir::WalkDir;
@@ -96,6 +97,42 @@ struct OpenGrepRun {
 struct ScanJobOutcome {
     findings: Vec<OpenGrepFinding>,
     partial_reason: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct FileIdentity {
+    digest: [u8; 32],
+    extension: Option<OsString>,
+}
+
+#[derive(Debug, Default)]
+struct PackageScanCache {
+    findings_by_file: HashMap<FileIdentity, Vec<OpenGrepFinding>>,
+}
+
+#[derive(Debug)]
+struct RetainedFile {
+    identity: FileIdentity,
+    path: String,
+}
+
+#[derive(Debug)]
+struct ReusedFile {
+    findings: Vec<OpenGrepFinding>,
+    path: String,
+}
+
+#[derive(Debug)]
+struct TargetPlan {
+    retained: Vec<RetainedFile>,
+    local_aliases: Vec<(String, String)>,
+    reused: Vec<ReusedFile>,
+}
+
+impl TargetPlan {
+    fn deduplicated_files(&self) -> usize {
+        self.local_aliases.len() + self.reused.len()
+    }
 }
 
 pub struct OpenGrepClient {
@@ -202,6 +239,7 @@ impl OpenGrepClient {
         );
         let mut findings = Vec::new();
         let mut warnings = Vec::new();
+        let mut package_cache = PackageScanCache::default();
         for distribution in &job.distributions {
             let distribution_started_at = Instant::now();
             let download_url: Url = distribution.parse()?;
@@ -220,21 +258,26 @@ impl OpenGrepClient {
                 }
                 Err(error) => return Err(error),
             };
-            let Some(remaining) = SCAN_DEADLINE.checked_sub(distribution_started_at.elapsed())
-            else {
-                warnings.push(format!(
-                    "Timed out downloading or extracting distribution {distribution}"
-                ));
-                break;
-            };
-            let deduplicated_files = deduplicate_target_files(directory.path())?;
+            let target_plan = prepare_target(directory.path(), &package_cache)?;
+            let deduplicated_files = target_plan.deduplicated_files();
             if deduplicated_files > 0 {
                 info!(
                     package = %job.name,
                     version = %job.version,
                     deduplicated_files,
-                    "Removed duplicate files before OpenGrep scan"
+                    "Reused file results before OpenGrep scan"
                 );
+            }
+            let reused_findings = synthesize_reused_findings(&target_plan, &inspector_url)?;
+            let Some(remaining) = SCAN_DEADLINE.checked_sub(distribution_started_at.elapsed())
+            else {
+                findings.extend(reused_findings);
+                warnings.push(format!("Timed out preparing distribution {distribution}"));
+                break;
+            };
+            if target_plan.retained.is_empty() {
+                findings.extend(reused_findings);
+                continue;
             }
             let distribution_run = match run_opengrep(
                 &self.binary,
@@ -245,12 +288,27 @@ impl OpenGrepClient {
             ) {
                 Ok(run) => run,
                 Err(error) if is_timeout_error(&error) => {
+                    findings.extend(reused_findings);
                     warnings.push(format!("Timed out scanning distribution {distribution}"));
                     break;
                 }
                 Err(error) => return Err(error),
             };
+            let mut alias_findings = synthesize_local_alias_findings(
+                &target_plan,
+                &distribution_run.findings,
+                &inspector_url,
+            )?;
+            if distribution_run.warnings.is_empty() {
+                cache_completed_file_results(
+                    &target_plan,
+                    &distribution_run.findings,
+                    &mut package_cache,
+                );
+            }
             findings.extend(distribution_run.findings);
+            findings.extend(reused_findings);
+            findings.append(&mut alias_findings);
             warnings.extend(distribution_run.warnings);
             ensure!(
                 findings.len() <= MAX_FINDINGS,
@@ -462,7 +520,7 @@ fn is_timeout_error(error: &color_eyre::Report) -> bool {
     })
 }
 
-fn deduplicate_target_files(target_directory: &Path) -> Result<usize> {
+fn prepare_target(target_directory: &Path, cache: &PackageScanCache) -> Result<TargetPlan> {
     let mut paths = WalkDir::new(target_directory)
         .follow_links(false)
         .into_iter()
@@ -474,61 +532,118 @@ fn deduplicate_target_files(target_directory: &Path) -> Result<usize> {
         .collect::<Result<Vec<_>, _>>()?;
     paths.sort_unstable();
 
-    let mut files_by_hash: HashMap<(u64, u64), Vec<PathBuf>> = HashMap::new();
-    let mut duplicate_count = 0;
+    let mut retained_by_identity: HashMap<FileIdentity, String> = HashMap::new();
+    let mut retained = Vec::new();
+    let mut local_aliases = Vec::new();
+    let mut reused = Vec::new();
     for path in paths {
-        let fingerprint = hash_file(&path)?;
-        let candidates = files_by_hash.entry(fingerprint).or_default();
-        let mut duplicate = false;
-        for candidate in candidates.iter() {
-            if files_equal(candidate, &path)? {
-                duplicate = true;
-                break;
-            }
+        if path.metadata()?.len() > APP_CONFIG.max_scan_size {
+            continue;
         }
-        if duplicate {
+        let relative_path = relative_target_path(&path, target_directory)?;
+        let identity = hash_file(&path)?;
+        if let Some(cached_findings) = cache.findings_by_file.get(&identity) {
             fs::remove_file(path)?;
-            duplicate_count += 1;
-        } else {
-            candidates.push(path);
+            reused.push(ReusedFile {
+                findings: cached_findings.clone(),
+                path: relative_path,
+            });
+            continue;
         }
+        if let Some(canonical_path) = retained_by_identity.get(&identity) {
+            fs::remove_file(path)?;
+            local_aliases.push((relative_path, canonical_path.clone()));
+            continue;
+        }
+        retained_by_identity.insert(identity.clone(), relative_path.clone());
+        retained.push(RetainedFile {
+            identity,
+            path: relative_path,
+        });
     }
-    Ok(duplicate_count)
+    Ok(TargetPlan {
+        retained,
+        local_aliases,
+        reused,
+    })
 }
 
-fn hash_file(path: &Path) -> Result<(u64, u64)> {
+fn hash_file(path: &Path) -> Result<FileIdentity> {
     let mut file = File::open(path)?;
-    let length = file.metadata()?.len();
-    let mut hasher = DefaultHasher::new();
+    let mut hasher = Sha256::new();
     let mut buffer = [0_u8; 8192];
     loop {
         let read = file.read(&mut buffer)?;
         if read == 0 {
             break;
         }
-        buffer[..read].hash(&mut hasher);
+        hasher.update(&buffer[..read]);
     }
-    Ok((length, hasher.finish()))
+    Ok(FileIdentity {
+        digest: hasher.finalize().into(),
+        extension: path.extension().map(OsString::from),
+    })
 }
 
-fn files_equal(first: &Path, second: &Path) -> Result<bool> {
-    let mut first = File::open(first)?;
-    let mut second = File::open(second)?;
-    let mut first_buffer = [0_u8; 8192];
-    let mut second_buffer = [0_u8; 8192];
-    loop {
-        let first_read = first.read(&mut first_buffer)?;
-        let second_read = second.read(&mut second_buffer)?;
-        if first_read != second_read {
-            return Ok(false);
-        }
-        if first_read == 0 {
-            return Ok(true);
-        }
-        if first_buffer[..first_read] != second_buffer[..second_read] {
-            return Ok(false);
-        }
+fn cache_completed_file_results(
+    target_plan: &TargetPlan,
+    findings: &[OpenGrepFinding],
+    cache: &mut PackageScanCache,
+) {
+    for file in &target_plan.retained {
+        let file_findings = findings
+            .iter()
+            .filter(|finding| finding.path == file.path)
+            .cloned()
+            .collect();
+        cache
+            .findings_by_file
+            .insert(file.identity.clone(), file_findings);
     }
+}
+
+fn synthesize_reused_findings(
+    target_plan: &TargetPlan,
+    inspector_base: &Url,
+) -> Result<Vec<OpenGrepFinding>> {
+    target_plan
+        .reused
+        .iter()
+        .flat_map(|file| {
+            file.findings
+                .iter()
+                .map(|finding| rewrite_finding_location(finding, &file.path, inspector_base))
+        })
+        .collect()
+}
+
+fn synthesize_local_alias_findings(
+    target_plan: &TargetPlan,
+    findings: &[OpenGrepFinding],
+    inspector_base: &Url,
+) -> Result<Vec<OpenGrepFinding>> {
+    target_plan
+        .local_aliases
+        .iter()
+        .flat_map(|(alias_path, canonical_path)| {
+            findings
+                .iter()
+                .filter(move |finding| finding.path == *canonical_path)
+                .map(|finding| rewrite_finding_location(finding, alias_path, inspector_base))
+        })
+        .collect()
+}
+
+fn rewrite_finding_location(
+    finding: &OpenGrepFinding,
+    path: &str,
+    inspector_base: &Url,
+) -> Result<OpenGrepFinding> {
+    ensure!(path.len() <= 1024, "finding path exceeds 1024 characters");
+    let mut finding = finding.clone();
+    path.clone_into(&mut finding.path);
+    finding.inspector_url = build_inspector_url(inspector_base, path)?;
+    Ok(finding)
 }
 
 fn read_bounded(file: &mut File) -> Result<String> {
@@ -548,27 +663,12 @@ fn normalize_finding(
     target_directory: &Path,
     inspector_base: &Url,
 ) -> Result<OpenGrepFinding> {
-    let relative_path = if finding.path.is_absolute() {
-        finding.path.strip_prefix(target_directory)?.to_path_buf()
-    } else {
-        finding.path
-    };
-    let relative_path = safe_relative_path(
-        relative_path
-            .to_str()
-            .ok_or_else(|| color_eyre::eyre::eyre!("finding path is not UTF-8"))?,
-    )?;
-    let path = relative_path.to_string_lossy().replace('\\', "/");
-    ensure!(path.len() <= 1024, "finding path exceeds 1024 characters");
+    let path = relative_target_path(&finding.path, target_directory)?;
     ensure!(
         finding.extra.message.len() <= 1024,
         "finding message exceeds 1024 characters"
     );
-    let inspector_url = format!("{}{}", inspector_base.as_str(), path);
-    ensure!(
-        inspector_url.len() <= 2048,
-        "finding inspector URL exceeds 2048 characters"
-    );
+    let inspector_url = build_inspector_url(inspector_base, &path)?;
     let rule_id = finding
         .check_id
         .rsplit_once('.')
@@ -588,6 +688,31 @@ fn normalize_finding(
     })
 }
 
+fn relative_target_path(path: &Path, target_directory: &Path) -> Result<String> {
+    let relative_path = if path.is_absolute() {
+        path.strip_prefix(target_directory)?.to_path_buf()
+    } else {
+        path.to_path_buf()
+    };
+    let relative_path = safe_relative_path(
+        relative_path
+            .to_str()
+            .ok_or_else(|| color_eyre::eyre::eyre!("finding path is not UTF-8"))?,
+    )?;
+    let path = relative_path.to_string_lossy().replace('\\', "/");
+    ensure!(path.len() <= 1024, "finding path exceeds 1024 characters");
+    Ok(path)
+}
+
+fn build_inspector_url(inspector_base: &Url, path: &str) -> Result<String> {
+    let inspector_url = format!("{}{}", inspector_base.as_str(), path);
+    ensure!(
+        inspector_url.len() <= 2048,
+        "finding inspector URL exceeds 2048 characters"
+    );
+    Ok(inspector_url)
+}
+
 fn truncate(value: &str, limit: usize) -> String {
     value.chars().take(limit).collect()
 }
@@ -595,10 +720,11 @@ fn truncate(value: &str, limit: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        deduplicate_target_files, materialize_rules, run_opengrep, safe_relative_path,
-        validate_staging_origin, SCAN_DEADLINE,
+        cache_completed_file_results, materialize_rules, prepare_target, run_opengrep,
+        safe_relative_path, synthesize_local_alias_findings, synthesize_reused_findings,
+        validate_staging_origin, PackageScanCache, SCAN_DEADLINE,
     };
-    use crate::client::OpenGrepRulesResponse;
+    use crate::client::{OpenGrepFinding, OpenGrepRulesResponse};
     use reqwest::Url;
     use std::{
         collections::HashMap,
@@ -816,18 +942,61 @@ printf '%s' '{
     }
 
     #[test]
-    fn duplicate_target_files_are_removed_after_content_comparison() {
-        let target = tempdir().unwrap();
-        let nested = target.path().join("nested");
+    fn package_cache_reuses_findings_for_duplicate_content() {
+        let first_target = tempdir().unwrap();
+        let nested = first_target.path().join("nested");
         std::fs::create_dir(&nested).unwrap();
-        std::fs::write(target.path().join("first.py"), "print('same')\n").unwrap();
+        std::fs::write(first_target.path().join("first.py"), "print('same')\n").unwrap();
         std::fs::write(nested.join("duplicate.py"), "print('same')\n").unwrap();
-        std::fs::write(target.path().join("different.py"), "print('diff')\n").unwrap();
+        let first_inspector = Url::parse("https://inspector.example/first/").unwrap();
+        let mut cache = PackageScanCache::default();
 
-        assert_eq!(deduplicate_target_files(target.path()).unwrap(), 1);
-        assert!(target.path().join("first.py").exists());
+        let first_plan = prepare_target(first_target.path(), &cache).unwrap();
+        assert_eq!(first_plan.deduplicated_files(), 1);
+        assert!(first_target.path().join("first.py").exists());
         assert!(!nested.join("duplicate.py").exists());
-        assert!(target.path().join("different.py").exists());
+        let first_finding = OpenGrepFinding {
+            rule_id: "python-test-exec".to_owned(),
+            path: "first.py".to_owned(),
+            start_line: 1,
+            end_line: 1,
+            message: "Dynamic execution.".to_owned(),
+            severity: "ERROR".to_owned(),
+            evidence: "composition".to_owned(),
+            confidence: "high".to_owned(),
+            execution_context: "import_time".to_owned(),
+            inspector_url: "https://inspector.example/first/first.py".to_owned(),
+        };
+        let alias_findings = synthesize_local_alias_findings(
+            &first_plan,
+            std::slice::from_ref(&first_finding),
+            &first_inspector,
+        )
+        .unwrap();
+        assert_eq!(alias_findings[0].path, "nested/duplicate.py");
+        cache_completed_file_results(
+            &first_plan,
+            std::slice::from_ref(&first_finding),
+            &mut cache,
+        );
+
+        let second_target = tempdir().unwrap();
+        std::fs::write(second_target.path().join("other.py"), "print('same')\n").unwrap();
+        std::fs::write(second_target.path().join("other.txt"), "print('same')\n").unwrap();
+        let second_plan = prepare_target(second_target.path(), &cache).unwrap();
+        let second_inspector = Url::parse("https://inspector.example/second/").unwrap();
+        let reused = synthesize_reused_findings(&second_plan, &second_inspector).unwrap();
+
+        assert_eq!(second_plan.deduplicated_files(), 1);
+        assert!(!second_target.path().join("other.py").exists());
+        assert!(second_target.path().join("other.txt").exists());
+        assert_eq!(reused.len(), 1);
+        assert_eq!(reused[0].rule_id, "python-test-exec");
+        assert_eq!(reused[0].path, "other.py");
+        assert_eq!(
+            reused[0].inspector_url,
+            "https://inspector.example/second/other.py"
+        );
     }
 
     #[cfg(unix)]

--- a/src/opengrep.rs
+++ b/src/opengrep.rs
@@ -263,8 +263,17 @@ impl OpenGrepClient {
                 }
                 Err(error) => return Err(error),
             };
-            let target_plan =
-                prepare_target(directory.path(), &package_cache, self.content_reuse_safe)?;
+            let distribution_deadline = distribution_started_at + SCAN_DEADLINE;
+            let Some(target_plan) = prepare_distribution_target(
+                directory.path(),
+                &package_cache,
+                self.content_reuse_safe,
+                distribution_deadline,
+            )?
+            else {
+                warnings.push(format!("Timed out preparing distribution {distribution}"));
+                break;
+            };
             let deduplicated_files = target_plan.deduplicated_files();
             if deduplicated_files > 0 {
                 info!(
@@ -540,16 +549,16 @@ fn prepare_target(
     target_directory: &Path,
     cache: &PackageScanCache,
     content_reuse_safe: bool,
+    deadline: Instant,
 ) -> Result<TargetPlan> {
-    let mut paths = WalkDir::new(target_directory)
-        .follow_links(false)
-        .into_iter()
-        .filter_map(|entry| match entry {
-            Ok(entry) if entry.file_type().is_file() => Some(Ok(entry.into_path())),
-            Ok(_) => None,
-            Err(error) => Some(Err(error)),
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    let mut paths = Vec::new();
+    for entry in WalkDir::new(target_directory).follow_links(false) {
+        ensure_scan_time_remaining(deadline)?;
+        let entry = entry?;
+        if entry.file_type().is_file() {
+            paths.push(entry.into_path());
+        }
+    }
     paths.sort_unstable();
 
     let mut retained_by_identity: HashMap<FileIdentity, String> = HashMap::new();
@@ -557,11 +566,12 @@ fn prepare_target(
     let mut local_aliases = Vec::new();
     let mut reused = Vec::new();
     for path in paths {
+        ensure_scan_time_remaining(deadline)?;
         if path.metadata()?.len() > APP_CONFIG.max_scan_size {
             continue;
         }
         let relative_path = relative_target_path(&path, target_directory)?;
-        let identity = hash_file(&path)?;
+        let identity = hash_file(&path, deadline)?;
         if let Some(cached_findings) = cache
             .findings_by_file
             .get(&identity)
@@ -595,11 +605,25 @@ fn prepare_target(
     })
 }
 
-fn hash_file(path: &Path) -> Result<FileIdentity> {
+fn prepare_distribution_target(
+    target_directory: &Path,
+    cache: &PackageScanCache,
+    content_reuse_safe: bool,
+    deadline: Instant,
+) -> Result<Option<TargetPlan>> {
+    match prepare_target(target_directory, cache, content_reuse_safe, deadline) {
+        Ok(plan) => Ok(Some(plan)),
+        Err(error) if is_timeout_error(&error) => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+fn hash_file(path: &Path, deadline: Instant) -> Result<FileIdentity> {
     let mut file = File::open(path)?;
     let mut hasher = Sha256::new();
     let mut buffer = [0_u8; 8192];
     loop {
+        ensure_scan_time_remaining(deadline)?;
         let read = file.read(&mut buffer)?;
         if read == 0 {
             break;
@@ -610,6 +634,13 @@ fn hash_file(path: &Path) -> Result<FileIdentity> {
         digest: hasher.finalize().into(),
         extension: path.extension().map(OsString::from),
     })
+}
+
+fn ensure_scan_time_remaining(deadline: Instant) -> Result<()> {
+    if Instant::now() >= deadline {
+        return Err(ScanTimeout("OpenGrep preparation exceeded the distribution deadline").into());
+    }
+    Ok(())
 }
 
 fn cache_completed_file_results(
@@ -747,16 +778,17 @@ fn truncate(value: &str, limit: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        cache_completed_file_results, materialize_rules, prepare_target, rules_allow_content_reuse,
-        run_opengrep, safe_relative_path, synthesize_local_alias_findings,
-        synthesize_reused_findings, validate_staging_origin, PackageScanCache, SCAN_DEADLINE,
+        cache_completed_file_results, is_timeout_error, materialize_rules, prepare_target,
+        rules_allow_content_reuse, run_opengrep, safe_relative_path,
+        synthesize_local_alias_findings, synthesize_reused_findings, validate_staging_origin,
+        PackageScanCache, SCAN_DEADLINE,
     };
     use crate::client::{OpenGrepFinding, OpenGrepRulesResponse};
     use reqwest::Url;
     use std::{
         collections::HashMap,
         path::{Path, PathBuf},
-        time::Duration,
+        time::{Duration, Instant},
     };
     use tempfile::tempdir;
 
@@ -1007,7 +1039,13 @@ printf '%s' '{
         let first_inspector = Url::parse("https://inspector.example/first/").unwrap();
         let mut cache = PackageScanCache::default();
 
-        let first_plan = prepare_target(first_target.path(), &cache, true).unwrap();
+        let first_plan = prepare_target(
+            first_target.path(),
+            &cache,
+            true,
+            Instant::now() + SCAN_DEADLINE,
+        )
+        .unwrap();
         assert_eq!(first_plan.deduplicated_files(), 1);
         assert!(first_target.path().join("first.py").exists());
         assert!(!nested.join("duplicate.py").exists());
@@ -1039,7 +1077,13 @@ printf '%s' '{
         let second_target = tempdir().unwrap();
         std::fs::write(second_target.path().join("other.py"), "print('same')\n").unwrap();
         std::fs::write(second_target.path().join("other.txt"), "print('same')\n").unwrap();
-        let second_plan = prepare_target(second_target.path(), &cache, true).unwrap();
+        let second_plan = prepare_target(
+            second_target.path(),
+            &cache,
+            true,
+            Instant::now() + SCAN_DEADLINE,
+        )
+        .unwrap();
         let second_inspector = Url::parse("https://inspector.example/second/").unwrap();
         let reused = synthesize_reused_findings(&second_plan, &second_inspector).unwrap();
 
@@ -1061,12 +1105,35 @@ printf '%s' '{
         std::fs::write(target.path().join("first.py"), "print('same')\n").unwrap();
         std::fs::write(target.path().join("second.py"), "print('same')\n").unwrap();
 
-        let plan = prepare_target(target.path(), &PackageScanCache::default(), false).unwrap();
+        let plan = prepare_target(
+            target.path(),
+            &PackageScanCache::default(),
+            false,
+            Instant::now() + SCAN_DEADLINE,
+        )
+        .unwrap();
 
         assert_eq!(plan.retained.len(), 2);
         assert_eq!(plan.deduplicated_files(), 0);
         assert!(target.path().join("first.py").exists());
         assert!(target.path().join("second.py").exists());
+    }
+
+    #[test]
+    fn target_preparation_observes_the_distribution_deadline() {
+        let target = tempdir().unwrap();
+        std::fs::write(target.path().join("sample.py"), "print('sample')\n").unwrap();
+
+        let error = prepare_target(
+            target.path(),
+            &PackageScanCache::default(),
+            true,
+            Instant::now(),
+        )
+        .unwrap_err();
+
+        assert!(is_timeout_error(&error));
+        assert!(target.path().join("sample.py").exists());
     }
 
     #[cfg(unix)]

--- a/src/opengrep.rs
+++ b/src/opengrep.rs
@@ -286,12 +286,12 @@ impl OpenGrepClient {
             let reused_findings = synthesize_reused_findings(&target_plan, &inspector_url)?;
             let Some(remaining) = SCAN_DEADLINE.checked_sub(distribution_started_at.elapsed())
             else {
-                findings.extend(reused_findings);
+                append_findings(&mut findings, reused_findings)?;
                 warnings.push(format!("Timed out preparing distribution {distribution}"));
                 break;
             };
             if target_plan.retained.is_empty() {
-                findings.extend(reused_findings);
+                append_findings(&mut findings, reused_findings)?;
                 continue;
             }
             let distribution_run = match run_opengrep(
@@ -303,13 +303,13 @@ impl OpenGrepClient {
             ) {
                 Ok(run) => run,
                 Err(error) if is_timeout_error(&error) => {
-                    findings.extend(reused_findings);
+                    append_findings(&mut findings, reused_findings)?;
                     warnings.push(format!("Timed out scanning distribution {distribution}"));
                     break;
                 }
                 Err(error) => return Err(error),
             };
-            let mut alias_findings = synthesize_local_alias_findings(
+            let alias_findings = synthesize_local_alias_findings(
                 &target_plan,
                 &distribution_run.findings,
                 &inspector_url,
@@ -321,14 +321,10 @@ impl OpenGrepClient {
                     &mut package_cache,
                 );
             }
-            findings.extend(distribution_run.findings);
-            findings.extend(reused_findings);
-            findings.append(&mut alias_findings);
+            append_findings(&mut findings, distribution_run.findings)?;
+            append_findings(&mut findings, reused_findings)?;
+            append_findings(&mut findings, alias_findings)?;
             warnings.extend(distribution_run.warnings);
-            ensure!(
-                findings.len() <= MAX_FINDINGS,
-                "OpenGrep produced more than {MAX_FINDINGS} findings"
-            );
         }
         let partial_reason = (!warnings.is_empty()).then(|| truncate(&warnings.join("; "), 2048));
         Ok(ScanJobOutcome {
@@ -336,6 +332,18 @@ impl OpenGrepClient {
             partial_reason,
         })
     }
+}
+
+fn append_findings(
+    findings: &mut Vec<OpenGrepFinding>,
+    additional: Vec<OpenGrepFinding>,
+) -> Result<()> {
+    ensure!(
+        findings.len().saturating_add(additional.len()) <= MAX_FINDINGS,
+        "OpenGrep produced more than {MAX_FINDINGS} findings"
+    );
+    findings.extend(additional);
+    Ok(())
 }
 
 /// Require the exact staging API origin without paths, credentials, or queries.
@@ -778,10 +786,10 @@ fn truncate(value: &str, limit: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        cache_completed_file_results, is_timeout_error, materialize_rules, prepare_target,
-        rules_allow_content_reuse, run_opengrep, safe_relative_path,
+        append_findings, cache_completed_file_results, is_timeout_error, materialize_rules,
+        prepare_target, rules_allow_content_reuse, run_opengrep, safe_relative_path,
         synthesize_local_alias_findings, synthesize_reused_findings, validate_staging_origin,
-        PackageScanCache, SCAN_DEADLINE,
+        PackageScanCache, MAX_FINDINGS, SCAN_DEADLINE,
     };
     use crate::client::{OpenGrepFinding, OpenGrepRulesResponse};
     use reqwest::Url;
@@ -1097,6 +1105,10 @@ printf '%s' '{
             reused[0].inspector_url,
             "https://inspector.example/second/other.py"
         );
+
+        let mut bounded = vec![reused[0].clone(); MAX_FINDINGS];
+        assert!(append_findings(&mut bounded, reused).is_err());
+        assert_eq!(bounded.len(), MAX_FINDINGS);
     }
 
     #[test]

--- a/src/opengrep.rs
+++ b/src/opengrep.rs
@@ -141,6 +141,7 @@ pub struct OpenGrepClient {
     base_url: String,
     binary: PathBuf,
     rules_directory: TempDir,
+    content_reuse_safe: bool,
     pub rules_hash: String,
 }
 
@@ -160,6 +161,7 @@ impl OpenGrepClient {
         let download_client = build_download_http_client()?;
         let response = fetch_opengrep_rules(&api_client, &APP_CONFIG.base_url)?;
         let rules_hash = response.hash.clone();
+        let content_reuse_safe = rules_allow_content_reuse(&response);
         let rules_directory = materialize_rules(&response)?;
         Ok(Self {
             api_client,
@@ -167,6 +169,7 @@ impl OpenGrepClient {
             base_url: APP_CONFIG.base_url.trim_end_matches('/').to_owned(),
             binary,
             rules_directory,
+            content_reuse_safe,
             rules_hash,
         })
     }
@@ -178,9 +181,11 @@ impl OpenGrepClient {
     /// Returns an error when retrieval or safe materialization fails.
     pub fn refresh_rules(&mut self) -> Result<()> {
         let response = fetch_opengrep_rules(&self.api_client, &self.base_url)?;
+        let content_reuse_safe = rules_allow_content_reuse(&response);
         let rules_directory = materialize_rules(&response)?;
         self.rules_hash = response.hash;
         self.rules_directory = rules_directory;
+        self.content_reuse_safe = content_reuse_safe;
         Ok(())
     }
 
@@ -258,7 +263,8 @@ impl OpenGrepClient {
                 }
                 Err(error) => return Err(error),
             };
-            let target_plan = prepare_target(directory.path(), &package_cache)?;
+            let target_plan =
+                prepare_target(directory.path(), &package_cache, self.content_reuse_safe)?;
             let deduplicated_files = target_plan.deduplicated_files();
             if deduplicated_files > 0 {
                 info!(
@@ -358,6 +364,16 @@ fn materialize_rules(response: &OpenGrepRulesResponse) -> Result<TempDir> {
         fs::write(destination, contents)?;
     }
     Ok(directory)
+}
+
+fn rules_allow_content_reuse(response: &OpenGrepRulesResponse) -> bool {
+    !response.rules.values().any(|contents| {
+        contents
+            .chars()
+            .filter(|character| !character.is_whitespace() && !matches!(character, '\'' | '"'))
+            .collect::<String>()
+            .contains("paths:")
+    })
 }
 
 fn safe_relative_path(value: &str) -> Result<PathBuf> {
@@ -520,7 +536,11 @@ fn is_timeout_error(error: &color_eyre::Report) -> bool {
     })
 }
 
-fn prepare_target(target_directory: &Path, cache: &PackageScanCache) -> Result<TargetPlan> {
+fn prepare_target(
+    target_directory: &Path,
+    cache: &PackageScanCache,
+    content_reuse_safe: bool,
+) -> Result<TargetPlan> {
     let mut paths = WalkDir::new(target_directory)
         .follow_links(false)
         .into_iter()
@@ -542,7 +562,11 @@ fn prepare_target(target_directory: &Path, cache: &PackageScanCache) -> Result<T
         }
         let relative_path = relative_target_path(&path, target_directory)?;
         let identity = hash_file(&path)?;
-        if let Some(cached_findings) = cache.findings_by_file.get(&identity) {
+        if let Some(cached_findings) = cache
+            .findings_by_file
+            .get(&identity)
+            .filter(|_| content_reuse_safe)
+        {
             fs::remove_file(path)?;
             reused.push(ReusedFile {
                 findings: cached_findings.clone(),
@@ -550,7 +574,10 @@ fn prepare_target(target_directory: &Path, cache: &PackageScanCache) -> Result<T
             });
             continue;
         }
-        if let Some(canonical_path) = retained_by_identity.get(&identity) {
+        if let Some(canonical_path) = retained_by_identity
+            .get(&identity)
+            .filter(|_| content_reuse_safe)
+        {
             fs::remove_file(path)?;
             local_aliases.push((relative_path, canonical_path.clone()));
             continue;
@@ -720,9 +747,9 @@ fn truncate(value: &str, limit: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        cache_completed_file_results, materialize_rules, prepare_target, run_opengrep,
-        safe_relative_path, synthesize_local_alias_findings, synthesize_reused_findings,
-        validate_staging_origin, PackageScanCache, SCAN_DEADLINE,
+        cache_completed_file_results, materialize_rules, prepare_target, rules_allow_content_reuse,
+        run_opengrep, safe_relative_path, synthesize_local_alias_findings,
+        synthesize_reused_findings, validate_staging_origin, PackageScanCache, SCAN_DEADLINE,
     };
     use crate::client::{OpenGrepFinding, OpenGrepRulesResponse};
     use reqwest::Url;
@@ -777,6 +804,35 @@ mod tests {
             std::fs::read_to_string(directory.path().join("python/payload.yml")).unwrap(),
             "rules: []"
         );
+    }
+
+    #[test]
+    fn path_scoped_rules_disable_content_reuse() {
+        let content_only = OpenGrepRulesResponse {
+            hash: "content-only".to_owned(),
+            rules: HashMap::from([(
+                "python/content.yml".to_owned(),
+                "rules:\n  - id: content-only\n    pattern: exec(...)\n".to_owned(),
+            )]),
+        };
+        let path_scoped = OpenGrepRulesResponse {
+            hash: "path-scoped".to_owned(),
+            rules: HashMap::from([(
+                "python/path.yml".to_owned(),
+                "rules:\n  - id: path-scoped\n    paths:\n      include: [src/**]\n".to_owned(),
+            )]),
+        };
+        let quoted_path_scoped = OpenGrepRulesResponse {
+            hash: "quoted-path-scoped".to_owned(),
+            rules: HashMap::from([(
+                "python/quoted-path.yml".to_owned(),
+                "rules:\n  - id: path-scoped\n    'paths' : {include: [src/**]}\n".to_owned(),
+            )]),
+        };
+
+        assert!(rules_allow_content_reuse(&content_only));
+        assert!(!rules_allow_content_reuse(&path_scoped));
+        assert!(!rules_allow_content_reuse(&quoted_path_scoped));
     }
 
     #[test]
@@ -951,7 +1007,7 @@ printf '%s' '{
         let first_inspector = Url::parse("https://inspector.example/first/").unwrap();
         let mut cache = PackageScanCache::default();
 
-        let first_plan = prepare_target(first_target.path(), &cache).unwrap();
+        let first_plan = prepare_target(first_target.path(), &cache, true).unwrap();
         assert_eq!(first_plan.deduplicated_files(), 1);
         assert!(first_target.path().join("first.py").exists());
         assert!(!nested.join("duplicate.py").exists());
@@ -983,7 +1039,7 @@ printf '%s' '{
         let second_target = tempdir().unwrap();
         std::fs::write(second_target.path().join("other.py"), "print('same')\n").unwrap();
         std::fs::write(second_target.path().join("other.txt"), "print('same')\n").unwrap();
-        let second_plan = prepare_target(second_target.path(), &cache).unwrap();
+        let second_plan = prepare_target(second_target.path(), &cache, true).unwrap();
         let second_inspector = Url::parse("https://inspector.example/second/").unwrap();
         let reused = synthesize_reused_findings(&second_plan, &second_inspector).unwrap();
 
@@ -997,6 +1053,20 @@ printf '%s' '{
             reused[0].inspector_url,
             "https://inspector.example/second/other.py"
         );
+    }
+
+    #[test]
+    fn path_scoped_corpus_preserves_duplicate_files() {
+        let target = tempdir().unwrap();
+        std::fs::write(target.path().join("first.py"), "print('same')\n").unwrap();
+        std::fs::write(target.path().join("second.py"), "print('same')\n").unwrap();
+
+        let plan = prepare_target(target.path(), &PackageScanCache::default(), false).unwrap();
+
+        assert_eq!(plan.retained.len(), 2);
+        assert_eq!(plan.deduplicated_files(), 0);
+        assert!(target.path().join("first.py").exists());
+        assert!(target.path().join("second.py").exists());
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

- preserve completed findings when OpenGrep reports rule timeouts or a package distribution reaches its scan deadline
- return bounded partial-scan diagnostics instead of discarding the package result
- cache completed per-file findings by SHA-256 across every package distribution
- remove previously scanned content before later OpenGrep invocations and clone cached findings onto each duplicate's path and Inspector URL
- emit partial-result and deduplication telemetry

## Compatibility

The optional `partial_reason` field is omitted for complete scans. Existing Mainframe versions continue accepting the success payload, and the extracted package directory remains disposable.

File extension remains part of the SHA-256 cache identity to preserve OpenGrep language selection. Partial scans do not populate new cache entries because absent findings are not authoritative after a timeout. Hash preparation is charged against the existing distribution deadline.

## Validation

- `OPENGREP_BIN=/home/rem/github/vipyrsec/.tools/bin/opengrep cargo test --all-targets --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `/home/rem/github/vipyrsec/.tools/bin/prek-workspace run --all-files`
